### PR TITLE
security: redact live round coordinates and enforce pano-only Street …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_ISSUER=https://accounts.google.com
 ADMIN_BOOTSTRAP_EMAILS=
+GOOGLE_MAPS_API_KEY=
 
 # Backend service addresses
 API_ADDR=:8080

--- a/apps/web/components/ui/types.ts
+++ b/apps/web/components/ui/types.ts
@@ -152,7 +152,7 @@ export type Snapshot = {
     roundId: string;
     roundNumber: number;
     timerStarted?: boolean;
-    location: { lat: number; lng: number; heading?: number; pitch?: number };
+    location: { lat: number; lng: number; panoId?: string; heading?: number; pitch?: number };
   };
   lastRoundResult?: RoundResult;
   roundResults?: RoundResult[];

--- a/apps/web/features/home/model/derive-home-model.test.ts
+++ b/apps/web/features/home/model/derive-home-model.test.ts
@@ -47,7 +47,7 @@ function createSnapshot(overrides: Partial<Snapshot> = {}): Snapshot {
     currentRound: {
       roundId: 'round-1',
       roundNumber: 3,
-      location: { lat: 1, lng: 2 }
+      location: { lat: 1, lng: 2, panoId: 'test-pano-id' }
     },
     players: {
       self: {
@@ -178,7 +178,7 @@ describe('deriveHomeModel', () => {
           roundId: 'round-1',
           roundNumber: 3,
           timerStarted: false,
-          location: { lat: 1, lng: 2 }
+          location: { lat: 1, lng: 2, panoId: 'test-pano-id' }
         }
       })),
       game: createGameState({ roundMSLeft: 0, displayRoundSeconds: 0 }),
@@ -204,7 +204,7 @@ describe('deriveHomeModel', () => {
         currentRound: {
           roundId: 'round-1',
           roundNumber: 1,
-          location: { lat: 1, lng: 2 }
+          location: { lat: 1, lng: 2, panoId: 'test-pano-id' }
         }
       })),
       game: createGameState({ roundMSLeft: 0, displayRoundSeconds: 0 }),
@@ -240,14 +240,14 @@ describe('deriveHomeModel', () => {
     expect(model.game.opponentDisconnected).toBe(true);
   });
 
-  it('includes the round camera heading and pitch in the Street View URL', () => {
+  it('uses pano-based Street View URL without exposing coordinates', () => {
     const model = deriveHomeModel({
       auth: createAuthState(),
       match: createMatchState(createSnapshot({
         currentRound: {
           roundId: 'round-1',
           roundNumber: 3,
-          location: { lat: 1, lng: 2, heading: 123.5, pitch: -4 }
+          location: { lat: 1, lng: 2, panoId: 'secure-pano', heading: 123.5, pitch: -4 }
         }
       })),
       game: createGameState(),
@@ -256,9 +256,28 @@ describe('deriveHomeModel', () => {
     });
 
     const streetViewURL = new URL(model.game.streetViewSrc);
-    expect(streetViewURL.searchParams.get('location')).toBe('1,2');
+    expect(streetViewURL.searchParams.get('pano')).toBe('secure-pano');
+    expect(streetViewURL.searchParams.get('location')).toBeNull();
     expect(streetViewURL.searchParams.get('heading')).toBe('123.5');
     expect(streetViewURL.searchParams.get('pitch')).toBe('-4');
+  });
+
+  it('returns empty Street View URL when panoId is missing', () => {
+    const model = deriveHomeModel({
+      auth: createAuthState(),
+      match: createMatchState(createSnapshot({
+        mode: 'singleplayer',
+        currentRound: {
+          roundId: 'round-1',
+          roundNumber: 1,
+          location: { lat: 12.34, lng: 56.78 }
+        }
+      })),
+      game: createGameState(),
+      config,
+      routeMatchId: 'match-1'
+    });
+    expect(model.game.streetViewSrc).toBe('');
   });
 
   it('derives round result overlay state', () => {

--- a/apps/web/features/home/model/derive-home-model.ts
+++ b/apps/web/features/home/model/derive-home-model.ts
@@ -32,13 +32,14 @@ export function formatHpPct(maxHP: number, hp: number) {
 }
 
 function buildStreetViewSrc(snapshot: Snapshot | null, googleEmbedKey: string) {
-  if (!snapshot?.currentRound) return "";
+  if (!googleEmbedKey || !snapshot?.currentRound) return "";
   const loc = snapshot.currentRound.location;
+  if (!loc.panoId) return "";
   const params = new URLSearchParams({
-    location: `${loc.lat},${loc.lng}`,
     key: googleEmbedKey,
     fov: "100",
     language: "en",
+    pano: loc.panoId,
   });
   if (Number.isFinite(loc.heading)) {
     params.set("heading", String(loc.heading));
@@ -64,7 +65,11 @@ function getSelfQueueName(params: {
   return direct;
 }
 
-function avatarFallback(value: string, fallback: string, noLinkedAccount = false) {
+function avatarFallback(
+  value: string,
+  fallback: string,
+  noLinkedAccount = false,
+) {
   if (noLinkedAccount) return "?";
   return (value || fallback).slice(0, 1).toUpperCase();
 }
@@ -186,7 +191,8 @@ export function deriveHomeModel({
   const opponentDisconnected = !!oppPlayer?.disconnected;
   const selfAvatarUrl = selfPlayer?.avatarUrl || auth.userAvatar;
   const oppAvatarUrl = oppPlayer?.avatarUrl || "";
-  const selfHasNoLinkedAccount = !auth.userEmail || !!(selfPlayer?.isGuest ?? auth.isGuest);
+  const selfHasNoLinkedAccount =
+    !auth.userEmail || !!(selfPlayer?.isGuest ?? auth.isGuest);
   const selfFallback = avatarFallback(
     selfName || auth.userEmail,
     "Y",
@@ -432,9 +438,7 @@ export function deriveHomeModel({
               opponentUserId: isSingleplayer ? undefined : oppId,
               selfElo: isSingleplayer ? undefined : selfElo,
               opponentElo: isSingleplayer ? undefined : opponentElo,
-              selfEloDelta: selfReceivesEloDelta
-                ? selfEloDelta
-                : undefined,
+              selfEloDelta: selfReceivesEloDelta ? selfEloDelta : undefined,
               opponentEloDelta: opponentReceivesEloDelta
                 ? opponentEloDelta
                 : undefined,

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -202,7 +202,7 @@ func ClientSnapshotForPlayer(snap *MatchSnapshot, userID string) *ClientMatchSna
 		RoundPhase:      snap.RoundPhase,
 		PhaseStartedAt:  snap.PhaseStartedAt,
 		PhaseEndsAt:     snap.PhaseEndsAt,
-		CurrentRound:    snap.CurrentRound,
+		CurrentRound:    clientCurrentRound(snap),
 		LastRoundResult: snap.LastRoundResult,
 		RoundResults:    snap.RoundResults,
 		RoundMSLeft:     snap.RoundMSLeft,
@@ -235,6 +235,31 @@ func ClientSnapshotForPlayer(snap *MatchSnapshot, userID string) *ClientMatchSna
 		}
 	}
 	return client
+}
+
+func clientCurrentRound(snap *MatchSnapshot) *RoundState {
+	if snap == nil || snap.CurrentRound == nil {
+		return nil
+	}
+	round := *snap.CurrentRound
+	if shouldRedactLiveLocation(snap) {
+		round.Location.Lat = 0
+		round.Location.Lng = 0
+		round.Location.Country = ""
+	}
+	return &round
+}
+
+func shouldRedactLiveLocation(snap *MatchSnapshot) bool {
+	if snap == nil || snap.Phase != PhaseLive {
+		return false
+	}
+	switch snap.RoundPhase {
+	case RoundPhaseIntro, RoundPhaseLive, RoundPhaseTransition:
+		return true
+	default:
+		return false
+	}
 }
 
 func clientSelfState(snap *MatchSnapshot, player PlayerState) *ClientSelfState {

--- a/pkg/contracts/contracts_test.go
+++ b/pkg/contracts/contracts_test.go
@@ -92,3 +92,38 @@ func TestClientSnapshotForPlayerKeepsZeroCoordinateSelfGuess(t *testing.T) {
 		t.Fatalf("expected zero-coordinate own guess, got lat=%v lng=%v", got.Lat, got.Lng)
 	}
 }
+
+func TestClientSnapshotForPlayerRedactsLiveRoundLocationCoordinates(t *testing.T) {
+	snap := &MatchSnapshot{
+		Phase:      PhaseLive,
+		RoundPhase: RoundPhaseLive,
+		CurrentRound: &RoundState{
+			RoundID:     "r1",
+			RoundNumber: 1,
+			Location: LocationPoint{
+				Lat:    51.5074,
+				Lng:    -0.1278,
+				PanoID: ptrString("pano-abc"),
+			},
+		},
+		Players: map[string]PlayerState{
+			"u1": {UserID: "u1"},
+		},
+	}
+
+	client := ClientSnapshotForPlayer(snap, "u1")
+	if client == nil || client.CurrentRound == nil {
+		t.Fatalf("expected current round in client snapshot")
+	}
+	if client.CurrentRound.Location.Lat != 0 || client.CurrentRound.Location.Lng != 0 {
+		t.Fatalf("expected live round coordinates to be redacted, got lat=%v lng=%v", client.CurrentRound.Location.Lat, client.CurrentRound.Location.Lng)
+	}
+	if client.CurrentRound.Location.PanoID == nil || *client.CurrentRound.Location.PanoID != "pano-abc" {
+		t.Fatalf("expected pano id to remain available")
+	}
+	if snap.CurrentRound.Location.Lat != 51.5074 || snap.CurrentRound.Location.Lng != -0.1278 {
+		t.Fatalf("expected original snapshot to remain unchanged")
+	}
+}
+
+func ptrString(v string) *string { return &v }

--- a/pkg/locationsampler/store.go
+++ b/pkg/locationsampler/store.go
@@ -73,7 +73,10 @@ func (d *DBStore) FetchRows(ctx context.Context, catalogID string, after float64
 	q := `
 		select id, lat, lng, country, pano_id, heading, pitch
 		from locations
-		where map_revision_id = $1 and rand_key >= $2
+		where map_revision_id = $1
+		  and rand_key >= $2
+		  and pano_id is not null
+		  and btrim(pano_id) <> ''
 		order by rand_key asc
 		limit $3
 	`
@@ -100,7 +103,10 @@ func (d *DBStore) FetchRows(ctx context.Context, catalogID string, after float64
 	rows2, err := d.pool.Query(ctx, `
 		select id, lat, lng, country, pano_id, heading, pitch
 		from locations
-		where map_revision_id = $1 and rand_key < $2
+		where map_revision_id = $1
+		  and rand_key < $2
+		  and pano_id is not null
+		  and btrim(pano_id) <> ''
 		order by rand_key asc
 		limit $3
 	`, catalogID, after, remaining)

--- a/scripts/enrich-panoids.mjs
+++ b/scripts/enrich-panoids.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+/**
+ * Backfill panoId values for a dataset JSON using Google Street View metadata.
+ *
+ * Input format: JSON array of objects containing at least { lat, lng }.
+ * Output format: same rows, with panoId filled when metadata status=OK.
+ *
+ * Usage:
+ *   node scripts/enrich-panoids.mjs \
+ *     --in datasets/a-source-world.json \
+ *     --out datasets/a-source-world.enriched.json \
+ *     --key "$GOOGLE_MAPS_API_KEY" \
+ *     --drop-missing true \
+ *     --qps 8
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+async function loadDotEnv(dotEnvPath) {
+  try {
+    const raw = await fs.readFile(dotEnvPath, "utf8");
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const idx = trimmed.indexOf("=");
+      if (idx <= 0) continue;
+      const key = trimmed.slice(0, idx).trim();
+      let value = trimmed.slice(idx + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // .env is optional
+  }
+}
+
+//Either feed from datasets.json or from DB
+function parseArgs(argv) {
+  const out = {
+    in: "datasets/a-source-world.json",
+    out: "datasets/a-source-world.enriched.json",
+    key: process.env.GOOGLE_MAPS_API_KEY || "",
+    dropMissing: true,
+    qps: 8,
+    source: "outdoor",
+    language: "en",
+    dbUpdate: false,
+    dbMapKey: process.env.LOCATION_MAP_KEY || "",
+    dbService: "postgres",
+    dbUser: process.env.POSTGRES_USER || "geoduels",
+    dbName: process.env.POSTGRES_DB || "geoduels",
+    dbTol: 1e-6,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const cur = argv[i];
+    const next = argv[i + 1];
+    if (cur === "--in" && next) ((out.in = next), i++);
+    else if (cur === "--out" && next) ((out.out = next), i++);
+    else if (cur === "--key" && next) ((out.key = next), i++);
+    else if (cur === "--drop-missing" && next)
+      ((out.dropMissing = next.toLowerCase() !== "false"), i++);
+    else if (cur === "--qps" && next)
+      ((out.qps = Math.max(1, Number(next) || 8)), i++);
+    else if (cur === "--source" && next) ((out.source = next), i++);
+    else if (cur === "--language" && next) ((out.language = next), i++);
+    else if (cur === "--db-update" && next)
+      ((out.dbUpdate = next.toLowerCase() === "true"), i++);
+    else if (cur === "--db-map-key" && next) ((out.dbMapKey = next), i++);
+    else if (cur === "--db-service" && next) ((out.dbService = next), i++);
+    else if (cur === "--db-user" && next) ((out.dbUser = next), i++);
+    else if (cur === "--db-name" && next) ((out.dbName = next), i++);
+    else if (cur === "--db-tol" && next)
+      ((out.dbTol = Math.max(0, Number(next) || 1e-6)), i++);
+  }
+  if (!out.key)
+    throw new Error("missing API key: set GOOGLE_MAPS_API_KEY or pass --key");
+  if (out.dbUpdate && !out.dbMapKey)
+    throw new Error(
+      "missing db map key: set LOCATION_MAP_KEY or pass --db-map-key",
+    );
+  return out;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function validCoord(lat, lng) {
+  return (
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+async function metadataLookup({ lat, lng, key, source, language }) {
+  const u = new URL("https://maps.googleapis.com/maps/api/streetview/metadata");
+  u.searchParams.set("location", `${lat},${lng}`);
+  u.searchParams.set("source", source);
+  u.searchParams.set("language", language);
+  u.searchParams.set("key", key);
+  const resp = await fetch(u, { method: "GET" });
+  if (!resp.ok) {
+    return { ok: false, status: `HTTP_${resp.status}` };
+  }
+  const body = await resp.json();
+  if (
+    body?.status === "OK" &&
+    typeof body?.pano_id === "string" &&
+    body.pano_id
+  ) {
+    return {
+      ok: true,
+      panoId: body.pano_id,
+      lat: Number(body?.location?.lat),
+      lng: Number(body?.location?.lng),
+    };
+  }
+  return { ok: false, status: String(body?.status || "UNKNOWN") };
+}
+
+function execCommand(command, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: false,
+      ...opts,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += String(d)));
+    child.stderr.on("data", (d) => (stderr += String(d)));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(new Error(`${command} exited ${code}: ${stderr || stdout}`));
+      }
+    });
+    if (opts.stdin) {
+      child.stdin.write(opts.stdin);
+    }
+    child.stdin.end();
+  });
+}
+
+async function applyDBUpdates(args, dbUpdates) {
+  if (!dbUpdates.length) return { updated: 0 };
+  const tol = args.dbTol;
+  const esc = (v) => String(v).replace(/'/g, "''");
+  const valuesSQL = dbUpdates
+    .map(
+      (r) =>
+        `(${Number(r.srcLat)}, ${Number(r.srcLng)}, '${esc(r.panoId)}', ${Number.isFinite(r.resolvedLat) ? Number(r.resolvedLat) : "NULL"}, ${Number.isFinite(r.resolvedLng) ? Number(r.resolvedLng) : "NULL"})`,
+    )
+    .join(",\n      ");
+  const sql = `
+with incoming(src_lat, src_lng, pano_id, resolved_lat, resolved_lng) as (
+  values
+      ${valuesSQL}
+),
+target_revision as (
+  select ma.active_revision_id as revision_id
+  from map_aliases ma
+  where ma.map_key = '${esc(args.dbMapKey)}'
+),
+updated as (
+  update locations l
+  set pano_id = i.pano_id
+  from incoming i, target_revision tr
+  where l.map_revision_id = tr.revision_id
+    and abs(l.lat - i.src_lat) <= ${tol}
+    and abs(l.lng - i.src_lng) <= ${tol}
+  returning l.id
+)
+select count(*)::int as updated_count from updated;
+`;
+
+  const cmdArgs = [
+    "compose",
+    "exec",
+    "-T",
+    args.dbService,
+    "psql",
+    "-U",
+    args.dbUser,
+    "-d",
+    args.dbName,
+    "-t",
+    "-A",
+    "-v",
+    "ON_ERROR_STOP=1",
+    "-c",
+    sql,
+  ];
+  const { stdout } = await execCommand("docker", cmdArgs);
+  const updated = Number(String(stdout).trim().split(/\s+/).pop()) || 0;
+  return { updated };
+}
+
+async function run() {
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const dotEnvPath = path.join(repoRoot, ".env");
+  await loadDotEnv(dotEnvPath);
+
+  const args = parseArgs(process.argv);
+  const raw = await fs.readFile(args.in, "utf8");
+  const input = JSON.parse(raw);
+  if (!Array.isArray(input)) {
+    throw new Error("input must be a JSON array");
+  }
+
+  const minDelayMs = Math.ceil(1000 / args.qps);
+  const output = [];
+  const dbUpdates = [];
+  const stats = {
+    total: input.length,
+    kept: 0,
+    enriched: 0,
+    alreadyHadPano: 0,
+    droppedInvalidCoord: 0,
+    droppedMissingPano: 0,
+    lookupFailures: 0,
+  };
+
+  for (let i = 0; i < input.length; i++) {
+    const row = input[i];
+    const lat = Number(row?.lat);
+    const lng = Number(row?.lng);
+    if (!validCoord(lat, lng)) {
+      stats.droppedInvalidCoord++;
+      continue;
+    }
+
+    const next = { ...row };
+    if (typeof next.panoId === "string" && next.panoId.trim() !== "") {
+      stats.alreadyHadPano++;
+      output.push(next);
+      stats.kept++;
+      continue;
+    }
+
+    const t0 = Date.now();
+    const res = await metadataLookup({
+      lat,
+      lng,
+      key: args.key,
+      source: args.source,
+      language: args.language,
+    });
+    const elapsed = Date.now() - t0;
+    if (elapsed < minDelayMs) {
+      await sleep(minDelayMs - elapsed);
+    }
+
+    if (res.ok) {
+      next.panoId = res.panoId;
+      // Optional normalization to Google's resolved pano coordinate.
+      if (validCoord(res.lat, res.lng)) {
+        next.lat = res.lat;
+        next.lng = res.lng;
+      }
+      output.push(next);
+      stats.enriched++;
+      stats.kept++;
+      dbUpdates.push({
+        srcLat: lat,
+        srcLng: lng,
+        panoId: res.panoId,
+        resolvedLat: res.lat,
+        resolvedLng: res.lng,
+      });
+    } else if (!args.dropMissing) {
+      output.push(next);
+      stats.kept++;
+      stats.lookupFailures++;
+    } else {
+      stats.droppedMissingPano++;
+      stats.lookupFailures++;
+    }
+  }
+
+  await fs.mkdir(path.dirname(args.out), { recursive: true });
+  await fs.writeFile(args.out, JSON.stringify(output, null, 2), "utf8");
+  let dbResult = { updated: 0 };
+  if (args.dbUpdate) {
+    dbResult = await applyDBUpdates(args, dbUpdates);
+  }
+
+  process.stdout.write(
+    JSON.stringify(
+      {
+        input: args.in,
+        output: args.out,
+        dbUpdate: args.dbUpdate,
+        dbMapKey: args.dbMapKey || null,
+        dbRowsUpdated: dbResult.updated,
+        ...stats,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+run().catch((err) => {
+  process.stderr.write(
+    `enrich-panoids failed: ${err?.message || String(err)}\n`,
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
The purpose of this PR is to fix the location leakage in live matches by removing coordinate-based Street View URLs and switching to panorama based rendering.

 Before:
<img width="808" height="55" alt="image" src="https://github.com/user-attachments/assets/fa9b0745-25b0-426a-b0c1-c32b10001eea" />
 
 After:
<img width="699" height="87" alt="image" src="https://github.com/user-attachments/assets/6eceef28-f982-4aad-bbb9-28512f722545" />
 
 Steps I had to do:
- Add the new value from .env.example to your local .env: GOOGLE_MAPS_API_KEY=... (only this one is new for this PR flow). You probably can just add to the current APIKEY the Street View Metadata API

 - Run node scripts/enrich-panoids.mjs to enrich the dataset file with panoId.
 
- Use --in and --out if you want custom files, example: node scripts/enrich-panoids.mjs --in datasets/a-source-world.json --out datasets/a-source-world.enriched.json.

 - Use --db-update true if you want to write results directly to DB (locations.pano_id on the active map revision).
 
 - You can override DB target with --db-map-key <map_key> if needed.
 
 - Google API key requirements: enable Street View Metadata API and enable Billing on the GCP project, but dont worry, from what I've seen its free to use the metadata endpoint
 
<img width="517" height="213" alt="image" src="https://github.com/user-attachments/assets/c9bf046a-dc98-4500-a275-99cfef040acc" />

But check it for yourself:
https://console.cloud.google.com/apis/library/street-view-image-backend.googleapis.com?project=<YOUR_PROJECT>


 - After enrichment/DB update, restart services and start a new match to validate pano URLs are used and location=lat,lng is no longer exposed.
