### PR TITLE
Update icon image filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="apps/web/public/icon.png" height=64 />
+<img src="apps/web/public/icon.v1.png" height=64 />
 
 # GeoDuels
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,5 @@ Triggered by git tag push.
 - `infra/k3s/base` - base k8s manifests
 - `infra/k3s/overlays/k3d` - local 3-node k3d overlay for routing/scaling tests
 - production overlays and Flux cluster state live in the private ops repository
-- `infra/k3s/overlays/k3d` - local 3-node k3d overlay for routing/scaling tests
 - `services/*/Dockerfile`, `apps/web/Dockerfile`, `workers/location-ingest/Dockerfile` - production image definitions
 - `docs/architecture.md` - current runtime architecture


### PR DESCRIPTION
Fixes the geoduels icon not loading in the README due to https://github.com/sourcelocation/geoduels/commit/ce5395e77a921b23462656aa81670d1c63ec473b

<img width="303" height="304" alt="image" src="https://github.com/user-attachments/assets/efff0ee3-19c8-4b52-85cb-89563291c3ad" />

Sorry i decided to fix the smallest thing ever cause there are no open issues 😅 amazing project btw love it!
