### PR TITLE
Add direction HUD

### DIFF
--- a/apps/web/components/home/InGameScene.test.tsx
+++ b/apps/web/components/home/InGameScene.test.tsx
@@ -6,7 +6,7 @@ import type { InGameSceneProps } from './InGameScene';
 function createProps(overrides: Partial<InGameSceneProps> = {}): InGameSceneProps {
   return {
     uiPhase: 'live_round',
-    streetViewSrc: 'https://www.google.com/maps/embed/v1/streetview?key=test&pano=pano-1',
+    streetViewSrc: 'https://www.google.com/maps/embed/v1/streetview?key=test&pano=pano-1&heading=93.5',
     streetViewInteractive: true,
     showResultStage: false,
     isSingleplayer: false,
@@ -78,6 +78,27 @@ describe('InGameScene', () => {
     const streetViewFrame = screen.getByTitle('Street View');
 
     expect(streetViewFrame).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('shows a top-centered direction HUD from the Street View heading', () => {
+    render(<InGameScene {...createProps()} />);
+
+    expect(screen.getByTestId('direction-hud')).toBeInTheDocument();
+    expect(screen.getByTestId('direction-hud-heading')).toHaveTextContent('E 94°');
+  });
+
+  it('updates the direction HUD when the Street View source heading changes', () => {
+    const { rerender } = render(<InGameScene {...createProps()} />);
+
+    rerender(
+      <InGameScene
+        {...createProps({
+          streetViewSrc: 'https://www.google.com/maps/embed/v1/streetview?key=test&pano=pano-2&heading=181',
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId('direction-hud-heading')).toHaveTextContent('S 181°');
   });
 
   it('releases focus if the Street View iframe captures it', () => {

--- a/apps/web/components/home/InGameScene.tsx
+++ b/apps/web/components/home/InGameScene.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { AlertTriangle, LogOut, RotateCcw, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState, useMemo, type ReactNode } from 'react';
+import DirectionHUD from '../ui/DirectionHUD';
 import GameHUD from '../ui/GameHUD';
 import MinimapPanel from '../ui/MinimapPanel';
 import PlayerHPCard from '../ui/PlayerHPCard';
@@ -14,6 +15,7 @@ import { ResultDistanceBar } from '../ui/RoundResultOverlay';
 import type { RatingDeltaPreview, RoundResultOverlayProps, UIPhase } from '../ui/types';
 import type { PlayerBadgeInfo } from '../ui/PlayerBadge';
 import type { ParticipantIdentityView } from '../ui/PlayerIdentity';
+import StreetViewPane, { getStreetViewInitialHeading } from './StreetViewPane';
 
 export type InGameSceneProps = {
   uiPhase: UIPhase;
@@ -142,6 +144,7 @@ export default function InGameScene({
   const [confirmForfeit, setConfirmForfeit] = useState(false);
   const [forfeitRequested, setForfeitRequested] = useState(false);
   const [streetViewResetCount, setStreetViewResetCount] = useState(0);
+  const [streetViewHeading, setStreetViewHeading] = useState(() => getStreetViewInitialHeading(streetViewSrc));
   const sceneRef = useRef<HTMLElement | null>(null);
   const streetViewFrameRef = useRef<HTMLIFrameElement | null>(null);
   const canShowForfeit = uiPhase !== 'match_end';
@@ -209,6 +212,7 @@ export default function InGameScene({
 
   useEffect(() => {
     setStreetViewResetCount(0);
+    setStreetViewHeading(getStreetViewInitialHeading(streetViewSrc));
   }, [streetViewSrc]);
 
   useEffect(() => {
@@ -245,20 +249,21 @@ export default function InGameScene({
     >
       {(uiPhase === 'live_round' || uiPhase === 'prematch_countdown') && (
         <div className="absolute inset-0 overflow-hidden">
-          <iframe
-            key={`${streetViewSrc}-${streetViewResetCount}`}
-            ref={streetViewFrameRef}
-            title="Street View"
+          <StreetViewPane
             src={streetViewSrc}
-            tabIndex={-1}
-            onFocus={releaseStreetViewFocus}
-            className={`absolute left-0 top-[-75px] h-[calc(100%+75px)] w-full border-0 ${streetViewInteractive ? '' : 'pointer-events-none'}`}
-            allowFullScreen
-            loading="eager"
+            interactive={streetViewInteractive}
+            resetCount={streetViewResetCount}
+            iframeRef={streetViewFrameRef}
+            onFrameFocus={releaseStreetViewFocus}
+            onHeadingChange={setStreetViewHeading}
           />
           {!streetViewInteractive ? <div className="absolute inset-0 z-[1]" aria-hidden="true" /> : null}
         </div>
       )}
+
+      {(uiPhase === 'live_round' || uiPhase === 'prematch_countdown') && streetViewSrc ? (
+        <DirectionHUD heading={streetViewHeading} />
+      ) : null}
 
       <AnimatePresence>
         {showResultStage && resultOverlay && <RoundResultOverlay {...resultOverlay} />}

--- a/apps/web/components/home/StreetViewPane.test.tsx
+++ b/apps/web/components/home/StreetViewPane.test.tsx
@@ -1,0 +1,57 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import StreetViewPane from './StreetViewPane';
+
+describe('StreetViewPane', () => {
+  afterEach(() => {
+    cleanup();
+    delete window.google;
+  });
+
+  it('reports Google Street View pov changes as heading updates', async () => {
+    let pov = { heading: 12, pitch: 0, zoom: 0 };
+    let povChanged: (() => void) | undefined;
+    const onHeadingChange = vi.fn();
+    const setPov = vi.fn((nextPov: typeof pov) => {
+      pov = nextPov;
+    });
+
+    window.google = {
+      maps: {
+        StreetViewPanorama: vi.fn(function StreetViewPanorama() {
+          return {
+            addListener: vi.fn((eventName: string, handler: () => void) => {
+              if (eventName === 'pov_changed') povChanged = handler;
+              return { remove: vi.fn() };
+            }),
+            getPov: vi.fn(() => pov),
+            setPano: vi.fn(),
+            setPov,
+          };
+        }),
+      },
+    };
+
+    render(
+      <StreetViewPane
+        src="https://www.google.com/maps/embed/v1/streetview?key=test&pano=pano-1&heading=12"
+        interactive
+        resetCount={0}
+        iframeRef={createRef<HTMLIFrameElement>()}
+        onFrameFocus={vi.fn()}
+        onHeadingChange={onHeadingChange}
+      />,
+    );
+
+    await waitFor(() => expect(povChanged).toBeDefined());
+    expect(onHeadingChange).toHaveBeenCalledWith(12);
+
+    act(() => {
+      pov = { heading: 91.8, pitch: 0, zoom: 0 };
+      povChanged?.();
+    });
+
+    expect(onHeadingChange.mock.calls.at(-1)?.[0]).toBeCloseTo(91.8);
+  });
+});

--- a/apps/web/components/home/StreetViewPane.tsx
+++ b/apps/web/components/home/StreetViewPane.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+
+type StreetViewPaneProps = {
+  src: string;
+  interactive: boolean;
+  resetCount: number;
+  iframeRef: RefObject<HTMLIFrameElement>;
+  onFrameFocus: () => void;
+  onHeadingChange: (heading: number) => void;
+};
+
+type StreetViewConfig = {
+  key: string;
+  pano: string;
+  heading: number;
+  pitch: number;
+};
+
+type GoogleMapsEventListener = {
+  remove: () => void;
+};
+
+type GoogleStreetViewPov = {
+  heading?: number;
+  pitch?: number;
+  zoom?: number;
+};
+
+type GoogleStreetViewPanorama = {
+  addListener: (eventName: 'pov_changed', handler: () => void) => GoogleMapsEventListener;
+  getPov: () => GoogleStreetViewPov;
+  setPano: (pano: string) => void;
+  setPov: (pov: GoogleStreetViewPov) => void;
+};
+
+type GoogleMapsNamespace = {
+  StreetViewPanorama: new (
+    element: HTMLElement,
+    options: {
+      pano: string;
+      pov: Required<Pick<GoogleStreetViewPov, 'heading' | 'pitch'>> & Pick<GoogleStreetViewPov, 'zoom'>;
+      visible: boolean;
+      addressControl: boolean;
+      fullscreenControl: boolean;
+      motionTracking: boolean;
+      motionTrackingControl: boolean;
+      showRoadLabels: boolean;
+    },
+  ) => GoogleStreetViewPanorama;
+};
+
+declare global {
+  interface Window {
+    google?: {
+      maps?: GoogleMapsNamespace;
+    };
+  }
+}
+
+let mapsScriptPromise: Promise<void> | null = null;
+let mapsScriptKey = '';
+
+function normalizeHeading(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return ((value % 360) + 360) % 360;
+}
+
+function readNumberParam(params: URLSearchParams, key: string, fallback: number) {
+  const raw = params.get(key);
+  if (raw === null) return fallback;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function getStreetViewConfig(src: string): StreetViewConfig | null {
+  try {
+    const url = new URL(src);
+    const key = url.searchParams.get('key')?.trim() || '';
+    const pano = url.searchParams.get('pano')?.trim() || '';
+    if (!key || key === 'NO_KEY_DEFINED' || !pano) return null;
+
+    return {
+      key,
+      pano,
+      heading: normalizeHeading(readNumberParam(url.searchParams, 'heading', 0)),
+      pitch: readNumberParam(url.searchParams, 'pitch', 0),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getStreetViewInitialHeading(src: string) {
+  try {
+    const url = new URL(src);
+    return normalizeHeading(readNumberParam(url.searchParams, 'heading', 0));
+  } catch {
+    return 0;
+  }
+}
+
+function loadGoogleMapsScript(key: string) {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('Google Maps is only available in the browser'));
+  }
+  if (window.google?.maps?.StreetViewPanorama) {
+    return Promise.resolve();
+  }
+  if (mapsScriptPromise && mapsScriptKey === key) {
+    return mapsScriptPromise;
+  }
+
+  const existingScript = document.querySelector<HTMLScriptElement>('script[data-geoduels-google-maps="true"]');
+  if (existingScript) {
+    mapsScriptPromise = new Promise((resolve, reject) => {
+      existingScript.addEventListener('load', () => resolve(), { once: true });
+      existingScript.addEventListener('error', () => reject(new Error('Failed to load Google Maps JavaScript API')), {
+        once: true,
+      });
+    });
+    mapsScriptKey = key;
+    return mapsScriptPromise;
+  }
+
+  mapsScriptPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    const params = new URLSearchParams({
+      key,
+      v: 'weekly',
+    });
+    script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
+    script.async = true;
+    script.defer = true;
+    script.dataset.geoduelsGoogleMaps = 'true';
+    script.addEventListener('load', () => resolve(), { once: true });
+    script.addEventListener('error', () => reject(new Error('Failed to load Google Maps JavaScript API')), {
+      once: true,
+    });
+    document.head.appendChild(script);
+  });
+  mapsScriptKey = key;
+  return mapsScriptPromise;
+}
+
+export default function StreetViewPane({
+  src,
+  interactive,
+  resetCount,
+  iframeRef,
+  onFrameFocus,
+  onHeadingChange,
+}: StreetViewPaneProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const panoramaRef = useRef<GoogleStreetViewPanorama | null>(null);
+  const povListenerRef = useRef<GoogleMapsEventListener | null>(null);
+  const config = useMemo(() => getStreetViewConfig(src), [src]);
+  const initialHeading = useMemo(() => getStreetViewInitialHeading(src), [src]);
+  const [panoramaReady, setPanoramaReady] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  useEffect(() => {
+    onHeadingChange(initialHeading);
+  }, [initialHeading, onHeadingChange]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPanoramaReady(false);
+    setLoadFailed(false);
+    panoramaRef.current = null;
+    povListenerRef.current?.remove();
+    povListenerRef.current = null;
+
+    if (!config) return;
+
+    loadGoogleMapsScript(config.key)
+      .then(() => {
+        if (cancelled || !containerRef.current || !window.google?.maps?.StreetViewPanorama) return;
+
+        const panorama = new window.google.maps.StreetViewPanorama(containerRef.current, {
+          pano: config.pano,
+          pov: {
+            heading: config.heading,
+            pitch: config.pitch,
+            zoom: 0,
+          },
+          visible: true,
+          addressControl: false,
+          fullscreenControl: false,
+          motionTracking: false,
+          motionTrackingControl: false,
+          showRoadLabels: false,
+        });
+
+        const handlePovChange = () => {
+          const pov = panorama.getPov();
+          onHeadingChange(normalizeHeading(Number(pov.heading ?? config.heading)));
+        };
+
+        panoramaRef.current = panorama;
+        povListenerRef.current = panorama.addListener('pov_changed', handlePovChange);
+        handlePovChange();
+        setPanoramaReady(true);
+      })
+      .catch(() => {
+        if (!cancelled) setLoadFailed(true);
+      });
+
+    return () => {
+      cancelled = true;
+      povListenerRef.current?.remove();
+      povListenerRef.current = null;
+      panoramaRef.current = null;
+    };
+  }, [config, onHeadingChange]);
+
+  useEffect(() => {
+    const panorama = panoramaRef.current;
+    if (!panorama || !config) return;
+
+    panorama.setPano(config.pano);
+    panorama.setPov({
+      heading: config.heading,
+      pitch: config.pitch,
+      zoom: 0,
+    });
+    onHeadingChange(config.heading);
+  }, [config, onHeadingChange, resetCount]);
+
+  const showFallbackFrame = !config || loadFailed || !panoramaReady;
+
+  return (
+    <>
+      <div
+        ref={containerRef}
+        aria-label="Street View"
+        className={[
+          'absolute inset-0',
+          panoramaReady ? '' : 'pointer-events-none opacity-0',
+          interactive ? '' : 'pointer-events-none',
+        ].join(' ')}
+      />
+      {showFallbackFrame ? (
+        <iframe
+          key={`${src}-${resetCount}`}
+          ref={iframeRef}
+          title="Street View"
+          src={src}
+          tabIndex={-1}
+          onFocus={onFrameFocus}
+          className={`absolute left-0 top-[-75px] h-[calc(100%+75px)] w-full border-0 ${interactive ? '' : 'pointer-events-none'}`}
+          allowFullScreen
+          loading="eager"
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/components/ui/DirectionHUD.tsx
+++ b/apps/web/components/ui/DirectionHUD.tsx
@@ -1,0 +1,117 @@
+type DirectionHUDProps = {
+  heading: number;
+};
+
+const COMPASS_MARKS = Array.from({ length: 72 }, (_, index) => index * 5);
+const VISIBLE_DEGREES = 120;
+const DIRECTION_LABELS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+
+function normalizeHeading(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return ((value % 360) + 360) % 360;
+}
+
+function normalizeDelta(value: number) {
+  return ((value + 540) % 360) - 180;
+}
+
+function getMarkLabel(degree: number) {
+  switch (degree) {
+    case 0:
+      return 'N';
+    case 45:
+      return 'NE';
+    case 90:
+      return 'E';
+    case 135:
+      return 'SE';
+    case 180:
+      return 'S';
+    case 225:
+      return 'SW';
+    case 270:
+      return 'W';
+    case 315:
+      return 'NW';
+    default:
+      return '';
+  }
+}
+
+export function formatHeadingLabel(heading: number) {
+  const normalized = normalizeHeading(heading);
+  const direction = DIRECTION_LABELS[Math.round(normalized / 45) % DIRECTION_LABELS.length];
+  return `${direction} ${Math.round(normalized)}°`;
+}
+
+export default function DirectionHUD({ heading }: DirectionHUDProps) {
+  const normalizedHeading = normalizeHeading(heading);
+  const halfVisibleDegrees = VISIBLE_DEGREES / 2;
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-3 z-40 flex justify-center px-3 md:top-4">
+      <div
+        data-testid="direction-hud"
+        className="relative h-12 w-[min(calc(100vw-1.5rem),26rem)] overflow-hidden rounded-lg border border-white/15 bg-[#111820]/75 text-white shadow-elev-2 backdrop-blur-hud"
+        aria-label={`Facing ${formatHeadingLabel(normalizedHeading)}`}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(255,255,255,0.16),transparent_44%)]" />
+        <div className="absolute inset-x-0 top-0 h-px bg-white/25" />
+        <div className="absolute inset-y-0 left-0 z-10 w-16 bg-gradient-to-r from-[#111820] to-transparent" />
+        <div className="absolute inset-y-0 right-0 z-10 w-16 bg-gradient-to-l from-[#111820] to-transparent" />
+
+        {COMPASS_MARKS.map((degree) => {
+          const delta = normalizeDelta(degree - normalizedHeading);
+          if (Math.abs(delta) > halfVisibleDegrees) return null;
+
+          const left = 50 + (delta / VISIBLE_DEGREES) * 100;
+          const label = getMarkLabel(degree);
+          const isCardinal = degree % 90 === 0;
+          const isIntercardinal = degree % 45 === 0;
+          const isNorth = degree === 0;
+
+          return (
+            <div
+              key={degree}
+              className="absolute top-2 flex -translate-x-1/2 flex-col items-center"
+              style={{ left: `${left}%` }}
+              aria-hidden="true"
+            >
+              <div
+                className={[
+                  'w-px rounded-full',
+                  isNorth
+                    ? 'h-6 bg-[#ff4f45] shadow-[0_0_12px_rgba(255,79,69,0.7)]'
+                    : isCardinal
+                      ? 'h-5 bg-white/90'
+                      : isIntercardinal
+                        ? 'h-4 bg-white/60'
+                        : 'h-2.5 bg-white/35',
+                ].join(' ')}
+              />
+              {label ? (
+                <span
+                  className={[
+                    'font-hud mt-0.5 text-[10px] font-black leading-none tracking-[0.12em]',
+                    isNorth ? 'text-[#ffb1ad]' : 'text-white/80',
+                  ].join(' ')}
+                >
+                  {label}
+                </span>
+              ) : null}
+            </div>
+          );
+        })}
+
+        <div className="absolute left-1/2 top-0 z-20 h-full w-px -translate-x-1/2 bg-white/80 shadow-[0_0_12px_rgba(255,255,255,0.55)]" />
+        <div className="absolute left-1/2 top-0 z-20 -translate-x-1/2 border-x-[6px] border-t-[8px] border-x-transparent border-t-[#ff4f45]" />
+        <div
+          data-testid="direction-hud-heading"
+          className="font-hud absolute bottom-1 left-1/2 z-20 -translate-x-1/2 whitespace-nowrap rounded bg-black/35 px-2 py-0.5 text-[10px] font-black leading-none tracking-[0.12em] text-white/90"
+        >
+          {formatHeadingLabel(normalizedHeading)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ui/GameHUD.tsx
+++ b/apps/web/components/ui/GameHUD.tsx
@@ -38,7 +38,7 @@ export default function GameHUD({
   const multiplierLabel = formatDamageMultiplierLabel(damageMultiplier);
 
   return (
-    <div className="pointer-events-none absolute inset-x-0 top-[91px] z-40 animate-hudSlideIn md:top-4">
+    <div className="pointer-events-none absolute inset-x-0 top-[91px] z-40 animate-hudSlideIn md:top-[76px]">
       <div className="absolute left-1/2 -translate-x-1/2">
         <div className="flex items-center gap-2.5 md:gap-3">
           <AnimatePresence initial={false}>


### PR DESCRIPTION
## Summary
- Add a top-centered GeoGuessr-style direction HUD over the live Street View scene.
- Replace iframe-only Street View rendering with a Google Maps JavaScript panorama wrapper that emits POV heading updates and falls back to the existing embed iframe if JS API loading is unavailable.
- Add focused tests for HUD rendering/source-heading updates and panorama pov_changed heading propagation.

## Validation
- npm --prefix apps/web run test -- InGameScene StreetViewPane
- npm --prefix apps/web run build
- proof-artifacts runtime proof with a temporary local proof route: HUD captured at E 90° and S 180° after a simulated panorama POV update; temporary route removed before commit.

Linear: KAI-10