### PR TITLE
KAI-12: Add singleplayer movement modes

### DIFF
--- a/apps/web/components/ui/LobbyScreen.tsx
+++ b/apps/web/components/ui/LobbyScreen.tsx
@@ -49,6 +49,25 @@ const PRESSURE_OPTIONS = [
   { value: "15", label: "15s" },
 ] as const;
 
+const DUEL_RULESET_OPTIONS = [
+  ["moving", "Moving"],
+  ["nmpz", "NMPZ"],
+] as const;
+
+const SINGLEPLAYER_RULESET_OPTIONS = [
+  ["moving", "Moving"],
+  ["no_move", "No Move"],
+  ["nmpz", "NMPZ"],
+] as const;
+
+function isDuelRuleset(value: unknown): value is GameRuleset {
+  return value === "moving" || value === "nmpz";
+}
+
+function isSingleplayerRuleset(value: unknown): value is GameRuleset {
+  return value === "moving" || value === "no_move" || value === "nmpz";
+}
+
 function lobbyTeamLabel(teamId?: string) {
   return teamId === "b" ? "Team Blue" : "Team Red";
 }
@@ -97,7 +116,7 @@ type Props = {
   status: string;
   queueStartedAt: number | null;
   joinQueue: (rulesets?: GameRuleset[]) => void;
-  startSingleplayer: () => void | Promise<string>;
+  startSingleplayer: (ruleset?: GameRuleset) => void | Promise<string>;
   cancelQueue: () => void;
   privateLobby?: PrivateLobbyView;
   createInviteLobby?: (mode?: PartyMode) => Promise<boolean>;
@@ -499,6 +518,7 @@ export default function LobbyScreen({
   const [isEditingProfileName, setIsEditingProfileName] = useState(false);
   const [isBlogExpanded, setIsBlogExpanded] = useState(false);
   const [queueRulesets, setQueueRulesets] = useState<GameRuleset[]>(["moving"]);
+  const [singleplayerRuleset, setSingleplayerRuleset] = useState<GameRuleset>("moving");
   const [inviteCopied, setInviteCopied] = useState(false);
   const [inviteCodeInput, setInviteCodeInput] = useState("");
   const [deleteConfirmation, setDeleteConfirmation] = useState("");
@@ -530,7 +550,7 @@ export default function LobbyScreen({
       const raw = window.localStorage.getItem("geoduels.queueRulesets");
       const parsed = raw ? JSON.parse(raw) : null;
       if (Array.isArray(parsed)) {
-        const next = parsed.filter((item): item is GameRuleset => item === "moving" || item === "nmpz");
+        const next = parsed.filter(isDuelRuleset);
         setQueueRulesets(Array.from(new Set(next)));
       }
     } catch {
@@ -545,6 +565,25 @@ export default function LobbyScreen({
       // Ignore storage failures; defaults still work.
     }
   }, [queueRulesets]);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("geoduels.singleplayerRuleset");
+      if (isSingleplayerRuleset(raw)) {
+        setSingleplayerRuleset(raw);
+      }
+    } catch {
+      setSingleplayerRuleset("moving");
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem("geoduels.singleplayerRuleset", singleplayerRuleset);
+    } catch {
+      // Ignore storage failures; defaults still work.
+    }
+  }, [singleplayerRuleset]);
 
   const isQueueing = status === "queueing";
   const isSingleplayerLoading = status === "matched_connecting";
@@ -2091,10 +2130,7 @@ export default function LobbyScreen({
 
                     {!isQueueing ? (
                       <div className="mb-3 overflow-hidden rounded-[14px] border border-white/10 bg-black/25">
-                        {([
-                          ["moving", "Moving"],
-                          ["nmpz", "NMPZ"],
-                        ] as const).map(([ruleset, label]) => (
+                        {DUEL_RULESET_OPTIONS.map(([ruleset, label]) => (
                           <button
                             key={ruleset}
                             type="button"
@@ -2185,8 +2221,37 @@ export default function LobbyScreen({
                   </div>
 
                   <div className="relative z-10 mx-auto mt-5 flex h-full w-full flex-col justify-end px-0 pb-1 sm:mt-6 sm:px-2">
+                    {!isSingleplayerLoading ? (
+                      <div className="mb-3 overflow-hidden rounded-[14px] border border-white/10 bg-black/25">
+                        {SINGLEPLAYER_RULESET_OPTIONS.map(([ruleset, label]) => (
+                          <button
+                            key={ruleset}
+                            type="button"
+                            aria-pressed={singleplayerRuleset === ruleset}
+                            onClick={() => setSingleplayerRuleset(ruleset)}
+                            className={`flex min-h-[44px] w-full items-center justify-between px-4 text-left text-[13px] font-extrabold uppercase tracking-[0.08em] transition ${
+                              singleplayerRuleset === ruleset
+                                ? "bg-[#3b82f6]/14 text-[#dbeafe]"
+                                : "text-white/70 hover:bg-white/[0.07] hover:text-white"
+                            }`}
+                          >
+                            <span>{label}</span>
+                            <span className="flex h-[18px] w-[18px] items-center justify-center">
+                              {singleplayerRuleset === ruleset ? (
+                                <CheckCircle2
+                                  size={18}
+                                  strokeWidth={2.5}
+                                  className="text-[#60a5fa]"
+                                />
+                              ) : null}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+
                     <button
-                      onClick={startSingleplayer}
+                      onClick={() => startSingleplayer(singleplayerRuleset)}
                       disabled={singleplayerDisabled}
                       className="w-full flex items-center justify-center rounded-[16px] bg-[#3b82f6] py-[14px] text-[16px] font-extrabold uppercase tracking-[0.08em] text-white shadow-[0_4px_16px_rgba(59,130,246,0.3)] transition-all duration-200 hover:scale-[1.01] hover:bg-[#4b8df8] hover:shadow-[0_6px_24px_rgba(59,130,246,0.4)] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:scale-100"
                     >

--- a/apps/web/components/ui/__tests__/LobbyScreen.test.tsx
+++ b/apps/web/components/ui/__tests__/LobbyScreen.test.tsx
@@ -90,10 +90,31 @@ describe('LobbyScreen', () => {
     const playButton = screen.getAllByRole('button', { name: 'Play' })[0];
     expect(playButton).not.toBeDisabled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Moving' }));
+    const duelMovingButton = screen.getAllByRole('button', { name: 'Moving' })[0];
+    fireEvent.click(duelMovingButton);
 
-    expect(screen.getByRole('button', { name: 'Moving' })).toHaveAttribute('aria-pressed', 'false');
+    expect(duelMovingButton).toHaveAttribute('aria-pressed', 'false');
     expect(playButton).toBeDisabled();
+  });
+
+  it('starts the selected singleplayer mode', () => {
+    const startSingleplayer = vi.fn();
+    renderLobbyScreen({ startSingleplayer });
+
+    const singleplayerMovingButton = screen.getAllByRole('button', { name: 'Moving' })[1];
+    const noMoveButton = screen.getByRole('button', { name: 'No Move' });
+    const nmpzButton = screen.getAllByRole('button', { name: 'NMPZ' })[1];
+
+    expect(singleplayerMovingButton).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(noMoveButton);
+
+    expect(singleplayerMovingButton).toHaveAttribute('aria-pressed', 'false');
+    expect(noMoveButton).toHaveAttribute('aria-pressed', 'true');
+    expect(nmpzButton).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Play' })[1]);
+
+    expect(startSingleplayer).toHaveBeenCalledWith('no_move');
   });
 
   it('shows singleplayer as loading while a start is connecting', () => {

--- a/apps/web/components/ui/types.ts
+++ b/apps/web/components/ui/types.ts
@@ -153,7 +153,7 @@ export type Snapshot = {
   matchId: string;
   mode?: "duel" | "singleplayer" | "team_duel" | "free_for_all";
   config?: {
-    ruleset?: "moving" | "nmpz";
+    ruleset?: "moving" | "no_move" | "nmpz";
     mapKey?: string;
     roundTimerMode?: "none" | "pressure" | "fixed";
     roundTimeLimitMs?: number;

--- a/apps/web/features/home/model/derive-home-model.test.ts
+++ b/apps/web/features/home/model/derive-home-model.test.ts
@@ -601,4 +601,21 @@ describe('deriveHomeModel', () => {
     expect(model.game.timerProgressPct).toBe(50);
     expect(model.game.isTimerCritical).toBe(true);
   });
+
+  it('derives no-move singleplayer restrictions from the match config', () => {
+    const model = deriveHomeModel({
+      auth: createAuthState(),
+      match: createMatchState(createSnapshot({
+        mode: 'singleplayer',
+        config: { ruleset: 'no_move' }
+      })),
+      game: createGameState(),
+      config,
+      routeMatchId: 'match-1'
+    });
+
+    expect(model.game.modeName).toBe('No Move Practice');
+    expect(model.game.mapName).toBe('A Source World');
+    expect(model.game.streetViewInteractive).toBe(false);
+  });
 });

--- a/apps/web/features/home/model/derive-home-model.ts
+++ b/apps/web/features/home/model/derive-home-model.ts
@@ -225,7 +225,12 @@ export function deriveHomeModel({
   const selfPlayer = snapshot?.players?.[selfId];
   const oppPlayer = oppId ? snapshot?.players?.[oppId] : undefined;
   const matchConfig = snapshot?.config || {};
-  const ruleset = matchConfig.ruleset === "nmpz" ? "nmpz" : "moving";
+  const ruleset =
+    matchConfig.ruleset === "nmpz"
+      ? "nmpz"
+      : matchConfig.ruleset === "no_move"
+        ? "no_move"
+        : "moving";
   const pressureTimeLimitMs =
     typeof matchConfig.pressureTimeLimitMs === "number" &&
     matchConfig.pressureTimeLimitMs > 0
@@ -585,7 +590,11 @@ export function deriveHomeModel({
       opponentGuessAlert: isPointsMode ? false : game.opponentGuessAlert,
       connectionIssue: match.connectionIssue,
       modeName: isSingleplayer
-        ? "Practice"
+        ? ruleset === "nmpz"
+          ? "NMPZ Practice"
+          : ruleset === "no_move"
+            ? "No Move Practice"
+            : "Practice"
         : isTeamDuel
           ? "Team Duel"
           : isFreeForAll
@@ -594,7 +603,7 @@ export function deriveHomeModel({
           ? "NMPZ"
           : "Moving",
       mapName: ruleset === "nmpz" ? "A Location World" : "A Source World",
-      streetViewInteractive: ruleset !== "nmpz",
+      streetViewInteractive: ruleset === "moving",
       selfUserId: selfId,
     },
     chat: {

--- a/apps/web/features/home/model/types.ts
+++ b/apps/web/features/home/model/types.ts
@@ -201,7 +201,7 @@ export type HomeViewModel = {
 
 export type HomeActions = {
   joinQueue: (rulesets?: GameRuleset[]) => void;
-  startSingleplayer: () => Promise<string>;
+  startSingleplayer: (ruleset?: GameRuleset) => Promise<string>;
   cancelQueue: () => void;
   createInviteLobby: (mode?: PartyMode) => Promise<boolean>;
   joinInviteLobby: (inviteCode?: string) => Promise<boolean>;

--- a/apps/web/features/matchmaking/controllers/match-controller.test.ts
+++ b/apps/web/features/matchmaking/controllers/match-controller.test.ts
@@ -493,7 +493,7 @@ describe('MatchController', () => {
     } as any;
 
     const controller = new MatchController({ config: runtimeConfig, sessionController });
-    const firstStart = controller.startSingleplayer();
+    const firstStart = controller.startSingleplayer('nmpz');
     const secondStart = await controller.startSingleplayer();
 
     expect(secondStart).toBe('');
@@ -503,6 +503,7 @@ describe('MatchController', () => {
     resolveSession(session);
     await expect(firstStart).resolves.toBe('solo-1');
     expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String((global.fetch as any).mock.calls[0]?.[1]?.body))).toEqual({ ruleset: 'nmpz' });
 
     controller.destroy();
   });

--- a/apps/web/features/matchmaking/controllers/match-controller.ts
+++ b/apps/web/features/matchmaking/controllers/match-controller.ts
@@ -51,6 +51,7 @@ export class MatchController extends ObservableStore<MatchState> {
   private recoverAbort: AbortController | null = null;
   private queueAbort: AbortController | null = null;
   private singleplayerStartInFlight = false;
+  private lastSingleplayerRuleset: GameRuleset = 'moving';
   private lastSocketOpenedAt = 0;
   private lastServerSeenAt = 0;
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
@@ -445,10 +446,11 @@ export class MatchController extends ObservableStore<MatchState> {
     })();
   };
 
-  startSingleplayer = async () => {
+  startSingleplayer = async (ruleset: GameRuleset = this.lastSingleplayerRuleset) => {
     if (this.singleplayerStartInFlight) {
       return '';
     }
+    this.lastSingleplayerRuleset = ruleset;
     this.singleplayerStartInFlight = true;
     this.recoverAbort?.abort();
     this.queueAbort?.abort();
@@ -464,7 +466,7 @@ export class MatchController extends ObservableStore<MatchState> {
         this.dispatchMatchmaking({ type: 'set_status', status: 'ready' });
         return '';
       }
-      const assignment = await startSingleplayerSession(this.config, session.accessToken, controller.signal);
+      const assignment = await startSingleplayerSession(this.config, session.accessToken, controller.signal, ruleset);
       if (!assignment.node || !assignment.ticket) {
         throw new Error('Singleplayer unavailable');
       }

--- a/apps/web/features/matchmaking/lib/queue-client.test.ts
+++ b/apps/web/features/matchmaking/lib/queue-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRuntimeConfigFixture } from '../../../test/runtime-config.fixture';
-import { bootstrapMatchSession, fetchMatchSession, resolveMatchRoute } from './queue-client';
+import { bootstrapMatchSession, fetchMatchSession, resolveMatchRoute, startSingleplayerSession } from './queue-client';
 
 describe('queue-client match bootstrap', () => {
   const originalFetch = global.fetch;
@@ -82,6 +82,35 @@ describe('queue-client match bootstrap', () => {
         wsPath: '/ws/game-1'
       }
     });
+  });
+
+  it('sends the selected ruleset when starting singleplayer', async () => {
+    global.fetch = vi.fn(async (_input, init) => {
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toEqual({
+        Authorization: 'Bearer access-token',
+        'Content-Type': 'application/json'
+      });
+      expect(JSON.parse(String(init?.body))).toEqual({ ruleset: 'nmpz' });
+      return {
+        ok: true,
+        json: async () => ({
+          matchId: 'solo-nmpz',
+          mode: 'singleplayer',
+          node: 'game-1',
+          ticket: 'ticket-1',
+          wsPath: '/ws/game-1'
+        })
+      } as Response;
+    }) as typeof fetch;
+
+    const response = await startSingleplayerSession(runtimeConfig, 'access-token', new AbortController().signal, 'nmpz');
+
+    expect(response.matchId).toBe('solo-nmpz');
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${runtimeConfig.apiURL}/v1/singleplayer/session`,
+      expect.objectContaining({ body: JSON.stringify({ ruleset: 'nmpz' }) })
+    );
   });
 
   it('resolves a public history route without an access token', async () => {

--- a/apps/web/features/matchmaking/lib/queue-client.ts
+++ b/apps/web/features/matchmaking/lib/queue-client.ts
@@ -3,7 +3,7 @@ import { normalizeHTTPBase, normalizeWSBase } from '../../../lib/runtime-config'
 import type { Snapshot } from '../../../components/ui/types';
 import type { AuthSessionSnapshot } from '../../auth/session';
 
-export type GameRuleset = 'moving' | 'nmpz';
+export type GameRuleset = 'moving' | 'no_move' | 'nmpz';
 export type MatchConfig = {
   ruleset?: GameRuleset;
   mapKey?: string;
@@ -373,11 +373,16 @@ export async function bootstrapMatchSession(
 export async function startSingleplayerSession(
   config: RuntimeConfig,
   accessToken: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  ruleset: GameRuleset = 'moving'
 ): Promise<{ matchId: string; mode?: string; ticket: string; node: string; wsPath: string }> {
   const resp = await fetch(`${config.apiURL}/v1/singleplayer/session`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${accessToken}` },
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ ruleset }),
     signal
   });
   if (!resp.ok) {

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -65,6 +65,7 @@ type GameRuleset string
 
 const (
 	RulesetMoving GameRuleset = "moving"
+	RulesetNoMove GameRuleset = "no_move"
 	RulesetNMPZ   GameRuleset = "nmpz"
 )
 
@@ -95,6 +96,8 @@ type MatchConfig struct {
 
 func NormalizeRuleset(v GameRuleset) GameRuleset {
 	switch v {
+	case RulesetNoMove:
+		return RulesetNoMove
 	case RulesetNMPZ:
 		return RulesetNMPZ
 	default:
@@ -452,7 +455,9 @@ type MatchAssignedPayload struct {
 }
 
 type SessionStartRequest struct {
-	Mode MatchMode `json:"mode"`
+	Mode    MatchMode   `json:"mode"`
+	Ruleset GameRuleset `json:"ruleset,omitempty"`
+	Config  MatchConfig `json:"config,omitempty"`
 }
 
 type MatchSessionResponse struct {

--- a/pkg/contracts/contracts_test.go
+++ b/pkg/contracts/contracts_test.go
@@ -132,3 +132,14 @@ func TestClientSnapshotForPlayerKeepsZeroCoordinateSelfGuess(t *testing.T) {
 		t.Fatalf("expected zero-coordinate own guess, got lat=%v lng=%v", got.Lat, got.Lng)
 	}
 }
+
+func TestNormalizeMatchConfigKeepsNoMoveOnMovingMap(t *testing.T) {
+	cfg := NormalizeMatchConfig(MatchConfig{Ruleset: RulesetNoMove})
+
+	if cfg.Ruleset != RulesetNoMove {
+		t.Fatalf("ruleset = %q, want %q", cfg.Ruleset, RulesetNoMove)
+	}
+	if cfg.MapKey != MapKeyMoving {
+		t.Fatalf("map key = %q, want %q", cfg.MapKey, MapKeyMoving)
+	}
+}

--- a/pkg/matchstore/store.go
+++ b/pkg/matchstore/store.go
@@ -187,7 +187,7 @@ const (
 )
 
 var allQueuePools = []QueuePool{QueuePoolGuest, QueuePoolRegistered}
-var allQueueRulesets = []contracts.GameRuleset{contracts.RulesetMoving, contracts.RulesetNMPZ}
+var allQueueRulesets = []contracts.GameRuleset{contracts.RulesetMoving, contracts.RulesetNoMove, contracts.RulesetNMPZ}
 
 func AllQueuePools() []QueuePool {
 	return append([]QueuePool(nil), allQueuePools...)

--- a/pkg/singleplayer/engine.go
+++ b/pkg/singleplayer/engine.go
@@ -20,6 +20,7 @@ type Guess struct {
 
 type Session struct {
 	ID              string
+	Config          contracts.MatchConfig
 	Player          *contracts.PlayerState
 	CurrentLocation contracts.LocationPoint
 	CurrentIndex    int
@@ -51,12 +52,17 @@ func New(roundProvider RoundProvider) *Engine {
 }
 
 func (e *Engine) CreateMatch(matchID string, playerIDs []string, profiles map[string]contracts.PlayerProfile) (*Session, error) {
+	return e.CreateMatchWithConfig(matchID, playerIDs, profiles, contracts.MatchConfig{})
+}
+
+func (e *Engine) CreateMatchWithConfig(matchID string, playerIDs []string, profiles map[string]contracts.PlayerProfile, config contracts.MatchConfig) (*Session, error) {
 	if len(playerIDs) != 1 {
 		return nil, errors.New("singleplayer requires exactly one player")
 	}
 	if e.roundProvider == nil {
 		return nil, errors.New("round provider required")
 	}
+	config = contracts.NormalizeMatchConfig(config)
 	firstRound, err := e.roundProvider(matchID, 0)
 	if err != nil {
 		return nil, err
@@ -75,6 +81,7 @@ func (e *Engine) CreateMatch(matchID string, playerIDs []string, profiles map[st
 	}
 	session := &Session{
 		ID:              matchID,
+		Config:          config,
 		Player:          &contracts.PlayerState{UserID: playerID, DisplayName: name, MMR: profile.MMR, RatingRD: profile.RatingRD, RankedGamesPlayed: profile.RankedGamesPlayed, AvatarURL: profile.AvatarURL, IsGuest: profile.IsGuest, IsAdmin: profile.IsAdmin, SelectedBadge: profile.SelectedBadge},
 		CurrentLocation: firstRound,
 		CurrentIndex:    0,
@@ -305,6 +312,7 @@ func (s *Session) snapshot() *contracts.MatchSnapshot {
 	return &contracts.MatchSnapshot{
 		MatchID:         s.ID,
 		Mode:            contracts.ModeSingleplayer,
+		Config:          contracts.NormalizeMatchConfig(s.Config),
 		State:           s.State,
 		Phase:           phase,
 		RoundPhase:      roundPhase,

--- a/pkg/singleplayer/engine_test.go
+++ b/pkg/singleplayer/engine_test.go
@@ -94,3 +94,30 @@ func TestSingleplayerDisconnectResume(t *testing.T) {
 		t.Fatal("expected player to be resumed")
 	}
 }
+
+func TestSingleplayerSnapshotKeepsConfig(t *testing.T) {
+	engine := New(func(matchID string, roundIndex int) (contracts.LocationPoint, error) {
+		return contracts.LocationPoint{
+			Lat:     float64(roundIndex),
+			Lng:     float64(roundIndex),
+			Country: "US",
+		}, nil
+	})
+	_, err := engine.CreateMatchWithConfig("solo-nmpz", []string{"u1"}, map[string]contracts.PlayerProfile{
+		"u1": {UserID: "u1", DisplayName: "Solo"},
+	}, contracts.MatchConfig{Ruleset: contracts.RulesetNMPZ})
+	if err != nil {
+		t.Fatalf("create match: %v", err)
+	}
+
+	snap, err := engine.GetSnapshot("solo-nmpz")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snap.Config.Ruleset != contracts.RulesetNMPZ {
+		t.Fatalf("ruleset = %q, want %q", snap.Config.Ruleset, contracts.RulesetNMPZ)
+	}
+	if snap.Config.MapKey != contracts.MapKeyNMPZ {
+		t.Fatalf("map key = %q, want %q", snap.Config.MapKey, contracts.MapKeyNMPZ)
+	}
+}

--- a/services/api/game_handlers.go
+++ b/services/api/game_handlers.go
@@ -502,10 +502,22 @@ func (a *api) startSession(w http.ResponseWriter, r *http.Request) {
 	mode := sessionpolicy.NormalizeMode(req.Mode, "")
 	switch mode {
 	case contracts.ModeSingleplayer:
-		a.startSingleplayerSession(w, r)
+		a.startSingleplayerSessionWithConfig(w, r, singleplayerConfigFromRequest(req.Ruleset, req.Config))
 	default:
 		http.Error(w, "unsupported mode", http.StatusBadRequest)
 	}
+}
+
+type startSingleplayerSessionRequest struct {
+	Ruleset contracts.GameRuleset `json:"ruleset,omitempty"`
+	Config  contracts.MatchConfig `json:"config,omitempty"`
+}
+
+func singleplayerConfigFromRequest(ruleset contracts.GameRuleset, config contracts.MatchConfig) contracts.MatchConfig {
+	if config.Ruleset == "" {
+		config.Ruleset = ruleset
+	}
+	return contracts.NormalizeMatchConfig(config)
 }
 
 func (a *api) startSingleplayerSession(w http.ResponseWriter, r *http.Request) {
@@ -518,6 +530,15 @@ func (a *api) startSingleplayerSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, maintenancePlayMessage(status), http.StatusServiceUnavailable)
 		return
 	}
+	var req startSingleplayerSessionRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	a.startSingleplayerSessionWithConfig(w, r, singleplayerConfigFromRequest(req.Ruleset, req.Config))
+}
+
+func (a *api) startSingleplayerSessionWithConfig(w http.ResponseWriter, r *http.Request, config contracts.MatchConfig) {
 	claims, err := a.authenticatedClaims(r)
 	if err != nil {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -575,7 +596,7 @@ func (a *api) startSingleplayerSession(w http.ResponseWriter, r *http.Request) {
 	found := contracts.MatchFound{
 		MatchID: "solo-" + soloSessionID(),
 		Mode:    contracts.ModeSingleplayer,
-		Config:  contracts.NormalizeMatchConfig(contracts.MatchConfig{Ruleset: contracts.RulesetMoving}),
+		Config:  contracts.NormalizeMatchConfig(config),
 		Players: []string{userID},
 		Profiles: map[string]contracts.PlayerProfile{
 			userID: {

--- a/services/api/game_handlers_test.go
+++ b/services/api/game_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,5 +167,31 @@ func TestMatchSessionAllowsGuestAssignedToLiveMatch(t *testing.T) {
 	}
 	if resp.MatchID != matchID || resp.Node != "node-1" || resp.WSPath != "/ws/node-1" || resp.Ticket == "" {
 		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestSingleplayerConfigFromRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want contracts.GameRuleset
+	}{
+		{name: "empty defaults moving", body: `{}`, want: contracts.RulesetMoving},
+		{name: "top level nmpz", body: `{"ruleset":"nmpz"}`, want: contracts.RulesetNMPZ},
+		{name: "config no move", body: `{"config":{"ruleset":"no_move"}}`, want: contracts.RulesetNoMove},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/singleplayer/session", strings.NewReader(tt.body))
+			var payload startSingleplayerSessionRequest
+			if err := decodeJSONBody(req, &payload); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			cfg := singleplayerConfigFromRequest(payload.Ruleset, payload.Config)
+			if cfg.Ruleset != tt.want {
+				t.Fatalf("ruleset = %q, want %q", cfg.Ruleset, tt.want)
+			}
+		})
 	}
 }

--- a/services/gameplay-node/main.go
+++ b/services/gameplay-node/main.go
@@ -121,8 +121,17 @@ func main() {
 	}
 
 	duelConfigs := newMatchConfigRegistry()
+	singleplayerConfigs := newMatchConfigRegistry()
 	roundForConfig := func(matchID string, roundIndex int) (contracts.LocationPoint, error) {
 		cfg := duelConfigs.Get(matchID)
+		sampler := samplers[cfg.MapKey]
+		if sampler == nil {
+			sampler = samplers[contracts.MapKeyMoving]
+		}
+		return sampler.NextRound(context.Background(), matchID, roundIndex)
+	}
+	roundForSingleplayerConfig := func(matchID string, roundIndex int) (contracts.LocationPoint, error) {
+		cfg := singleplayerConfigs.Get(matchID)
 		sampler := samplers[cfg.MapKey]
 		if sampler == nil {
 			sampler = samplers[contracts.MapKeyMoving]
@@ -143,12 +152,10 @@ func main() {
 		samplerCleanup: samplerCleanup,
 		redisCleanup:   redisCleanup,
 		runtimes: map[contracts.MatchMode]gameplayRuntime{
-			contracts.ModeDuel:       duelRuntime{mode: contracts.ModeDuel, engine: duel.New(roundForConfig), configs: duelConfigs},
-			contracts.ModeTeamDuel:   duelRuntime{mode: contracts.ModeTeamDuel, engine: duel.New(roundForConfig), configs: duelConfigs},
-			contracts.ModeFreeForAll: duelRuntime{mode: contracts.ModeFreeForAll, engine: duel.New(roundForConfig), configs: duelConfigs},
-			contracts.ModeSingleplayer: singleplayerRuntime{engine: singleplayer.New(func(matchID string, roundIndex int) (contracts.LocationPoint, error) {
-				return samplers[contracts.MapKeyMoving].NextRound(context.Background(), matchID, roundIndex)
-			})},
+			contracts.ModeDuel:         duelRuntime{mode: contracts.ModeDuel, engine: duel.New(roundForConfig), configs: duelConfigs},
+			contracts.ModeTeamDuel:     duelRuntime{mode: contracts.ModeTeamDuel, engine: duel.New(roundForConfig), configs: duelConfigs},
+			contracts.ModeFreeForAll:   duelRuntime{mode: contracts.ModeFreeForAll, engine: duel.New(roundForConfig), configs: duelConfigs},
+			contracts.ModeSingleplayer: singleplayerRuntime{engine: singleplayer.New(roundForSingleplayerConfig), configs: singleplayerConfigs},
 		},
 		conns:      map[string]*websocket.Conn{},
 		connWrite:  map[string]*sync.Mutex{},

--- a/services/gameplay-node/runtime.go
+++ b/services/gameplay-node/runtime.go
@@ -97,13 +97,18 @@ func (r duelRuntime) Tick() []string {
 }
 
 type singleplayerRuntime struct {
-	engine *singleplayer.Engine
+	engine  *singleplayer.Engine
+	configs *matchConfigRegistry
 }
 
 func (r singleplayerRuntime) Mode() contracts.MatchMode { return contracts.ModeSingleplayer }
 
 func (r singleplayerRuntime) CreateMatch(matchID string, playerIDs []string, profiles map[string]contracts.PlayerProfile, unranked bool, seasonID string, config contracts.MatchConfig, teams map[string]string) error {
-	_, err := r.engine.CreateMatch(matchID, playerIDs, profiles)
+	config = contracts.NormalizeMatchConfig(config)
+	if r.configs != nil {
+		r.configs.Set(matchID, config)
+	}
+	_, err := r.engine.CreateMatchWithConfig(matchID, playerIDs, profiles, config)
 	return err
 }
 

--- a/services/match-coordinator/main.go
+++ b/services/match-coordinator/main.go
@@ -166,7 +166,7 @@ func (q *matchCoordinator) runMatchmakingLoop(interval time.Duration, batchSize 
 			continue
 		}
 		for _, pool := range matchstore.AllQueuePools() {
-			for _, ruleset := range []contracts.GameRuleset{contracts.RulesetMoving, contracts.RulesetNMPZ} {
+			for _, ruleset := range []contracts.GameRuleset{contracts.RulesetMoving, contracts.RulesetNoMove, contracts.RulesetNMPZ} {
 				if _, err := q.store.RunMatchmaking(pool, ruleset, batchSize); err != nil {
 					observability.Log("warn", "matchmaking tick failed", map[string]any{"pool": string(pool), "ruleset": string(ruleset), "error": err.Error()})
 				}
@@ -396,7 +396,7 @@ func (q *matchCoordinator) heartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 	q.touchPresence(claims.Sub)
 
-	status, err := q.store.Heartbeat(matchstore.PoolForGuest(identity.AccountType == "guest"), []contracts.GameRuleset{contracts.RulesetMoving, contracts.RulesetNMPZ}, claims.Sub)
+	status, err := q.store.Heartbeat(matchstore.PoolForGuest(identity.AccountType == "guest"), []contracts.GameRuleset{contracts.RulesetMoving, contracts.RulesetNoMove, contracts.RulesetNMPZ}, claims.Sub)
 	if err != nil {
 		http.Error(w, "queue unavailable", http.StatusBadGateway)
 		return


### PR DESCRIPTION
## Summary\n- Add Moving, No Move, and NMPZ as single-select options on the singleplayer lobby card.\n- Send the selected singleplayer ruleset through the web client, API, gameplay node, and singleplayer engine snapshot.\n- Preserve NMPZ map sampling and no-move/non-interactive Street View behavior from the match config.\n\n## Validation\n- npm test\n- npm run build\n- docker run --rm -u "1001:1001" -v "/home/ubuntu/code/geoduels-workspaces/KAI-12":/repo -w /repo -e GOCACHE=/tmp/go-cache -e GOMODCACHE=/tmp/go-mod-cache golang:1.26.0 go test ./...\n- proof-artifacts runtime walkthrough of the singleplayer selector