### PR TITLE
fix: keep untimed rounds alive while players are active

### DIFF
--- a/pkg/duel/engine.go
+++ b/pkg/duel/engine.go
@@ -788,8 +788,17 @@ func (e *Engine) roundExpired(m *Match, now time.Time) bool {
 	if !m.RoundDeadline.IsZero() {
 		return now.After(m.RoundDeadline)
 	}
+	// No fixed deadline (time limit "none", or pressure mode before the first
+	// finalize). Fall back to an idle watchdog so genuinely abandoned rounds
+	// don't pin a gameplay node forever. Measure the idle window from the last
+	// player activity (pin placement/move, (re)connect) rather than the round
+	// start, so an actively-played unlimited round is never force-resolved.
 	liveAt := m.RoundStartedAt.Add(roundIntro)
-	return now.After(liveAt.Add(roundIdleCap))
+	idleSince := m.LastActivity
+	if idleSince.Before(liveAt) {
+		idleSince = liveAt
+	}
+	return now.After(idleSince.Add(roundIdleCap))
 }
 
 func roundID(matchID string, round int) string {

--- a/pkg/duel/engine_test.go
+++ b/pkg/duel/engine_test.go
@@ -560,6 +560,30 @@ func TestPlaceGuessDoesNotStartRoundTimer(t *testing.T) {
 	}
 }
 
+func TestActiveUntimedRoundDoesNotResolveAtIdleCap(t *testing.T) {
+	rounds := []contracts.LocationPoint{{Lat: 1, Lng: 1, Country: "US"}}
+	e := New(func(_ string, _ int) (contracts.LocationPoint, error) { return rounds[0], nil })
+	m, err := e.CreateMatch("m-active", []string{"u1", "u2"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Round started well beyond the idle cap ago, but players have stayed
+	// active: with "time limit = none" the round must not be force-resolved.
+	m.RoundStartedAt = time.Now().Add(-(roundIntro + roundIdleCap + time.Minute))
+	m.LastActivity = time.Now()
+	e.Tick()
+	snap, err := e.GetSnapshot("m-active")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Phase != contracts.PhaseLive {
+		t.Fatalf("expected active untimed round to stay live, got phase=%s", snap.Phase)
+	}
+	if snap.LastRoundResult != nil {
+		t.Fatalf("did not expect a round result for an active untimed round")
+	}
+}
+
 func TestIdleRoundCapResolvesUntimedRound(t *testing.T) {
 	rounds := []contracts.LocationPoint{{Lat: 1, Lng: 1, Country: "US"}}
 	e := New(func(_ string, _ int) (contracts.LocationPoint, error) { return rounds[0], nil })
@@ -567,7 +591,9 @@ func TestIdleRoundCapResolvesUntimedRound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m.RoundStartedAt = time.Now().Add(-(roundIntro + roundIdleCap + time.Second))
+	idlePast := time.Now().Add(-(roundIntro + roundIdleCap + time.Second))
+	m.RoundStartedAt = idlePast
+	m.LastActivity = idlePast
 	e.Tick()
 	snap, err := e.GetSnapshot("m-idle")
 	if err != nil {


### PR DESCRIPTION
The round idle watchdog measured its window from round start instead of last activity, so rounds with time limit "none" (and pressure off) were force-resolved after roundIdleCap, auto-scoring un-submitted guesses. Measure the idle window from LastActivity so actively-played unlimited rounds are never force-resolved while still cleaning up abandoned ones.