### PR TITLE
feat: add pressure duration options

### DIFF
--- a/apps/web/features/lobby/components/PartyPanel.tsx
+++ b/apps/web/features/lobby/components/PartyPanel.tsx
@@ -382,10 +382,10 @@ function PartySettings({
         <label className="grid gap-1.5">
           <LobbyFieldLabel>Pressure</LobbyFieldLabel>
           <LobbySelect
-            value={pressureOn ? "15" : "none"}
+            value={pressureOn ? String(pressureSeconds) : "none"}
             onChange={(event) => {
               const value = event.target.value;
-              saveConfig({ pressureTimeLimitMs: value === "15" ? 15000 : undefined });
+              saveConfig({ pressureTimeLimitMs: value === "none" ? undefined : Number(value) * 1000 });
             }}
             disabled={busy}
           >

--- a/apps/web/features/lobby/hooks/usePartyPanelState.ts
+++ b/apps/web/features/lobby/hooks/usePartyPanelState.ts
@@ -19,6 +19,8 @@ type UsePartyPanelStateInput = {
   setInviteCopied: (copied: boolean) => void;
 };
 
+const pressureTimeLimitsMs = new Set([15000, 30000, 60000, 90000]);
+
 const defaultPartyConfig: MatchConfig = {
   ruleset: "moving",
   roundTimerMode: "none",
@@ -80,7 +82,7 @@ export function usePartyPanelState({
     } else {
       next.roundTimeLimitMs = Math.max(10000, Math.min(120000, next.roundTimeLimitMs || 45000));
     }
-    if ((next.pressureTimeLimitMs || 0) !== 15000) {
+    if (!pressureTimeLimitsMs.has(next.pressureTimeLimitMs || 0)) {
       next.pressureTimeLimitMs = undefined;
     }
     void updateSettings(next);

--- a/apps/web/features/lobby/lib/lobby-ui.ts
+++ b/apps/web/features/lobby/lib/lobby-ui.ts
@@ -26,6 +26,9 @@ export const CLOCK_OPTIONS = [
 export const PRESSURE_OPTIONS = [
   { value: "none", label: "None" },
   { value: "15", label: "15s" },
+  { value: "30", label: "30s" },
+  { value: "60", label: "60s" },
+  { value: "90", label: "90s" },
 ] as const;
 
 export const NAV_ITEMS = APP_NAV_ITEMS;

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -165,7 +165,9 @@ func NormalizeMatchConfig(cfg MatchConfig) MatchConfig {
 		cfg.RoundTimerMode = RoundTimerNone
 		cfg.RoundTimeLimitMS = 0
 	}
-	if cfg.PressureTimeLimitMS != DefaultPressureTimeMS {
+	switch cfg.PressureTimeLimitMS {
+	case 0, DefaultPressureTimeMS, 30_000, 60_000, 90_000:
+	default:
 		cfg.PressureTimeLimitMS = 0
 	}
 	return cfg

--- a/pkg/contracts/contracts_test.go
+++ b/pkg/contracts/contracts_test.go
@@ -171,3 +171,21 @@ func TestNormalizeMatchConfigMigratesLegacyMapKey(t *testing.T) {
 		t.Fatalf("MapKey = %q, want empty after migration", config.MapKey)
 	}
 }
+
+func TestNormalizeMatchConfigKeepsAllowedPressureDurations(t *testing.T) {
+	for _, pressureTimeLimitMS := range []int64{15_000, 30_000, 60_000, 90_000} {
+		config := NormalizeMatchConfig(MatchConfig{PressureTimeLimitMS: pressureTimeLimitMS})
+
+		if config.PressureTimeLimitMS != pressureTimeLimitMS {
+			t.Fatalf("PressureTimeLimitMS = %d, want %d", config.PressureTimeLimitMS, pressureTimeLimitMS)
+		}
+	}
+}
+
+func TestNormalizeMatchConfigClearsUnsupportedPressureDurations(t *testing.T) {
+	config := NormalizeMatchConfig(MatchConfig{PressureTimeLimitMS: 45_000})
+
+	if config.PressureTimeLimitMS != 0 {
+		t.Fatalf("PressureTimeLimitMS = %d, want 0", config.PressureTimeLimitMS)
+	}
+}


### PR DESCRIPTION
Allow party pressure timers to use 30s, 60s, and 90s values for slower paced play or more difficult maps.