### PR TITLE
feat: add fullscreen toggle with F key

### DIFF
--- a/apps/web/features/app-shell/components/AppShell.tsx
+++ b/apps/web/features/app-shell/components/AppShell.tsx
@@ -9,6 +9,7 @@ import PlayerBadge, { type PlayerBadgeInfo } from "../../../components/ui/Player
 import PlayerNameWithBadge from "../../../components/ui/PlayerNameWithBadge";
 import { Tooltip } from "../../../components/ui/Tooltip";
 import { cn } from "../../../lib/cn";
+import { useFullscreenShortcut } from "../hooks/use-fullscreen-shortcut";
 import {
   APP_NAV_ITEMS,
   appNavRouteStorageKey,
@@ -84,6 +85,7 @@ export function AppShell({
   maintenanceBanner,
   contentClassName,
 }: AppShellProps) {
+  useFullscreenShortcut();
   const [highQualityBackgroundReady, setHighQualityBackgroundReady] =
     useState(backgroundLoaded);
 

--- a/apps/web/features/app-shell/hooks/use-fullscreen-shortcut.test.tsx
+++ b/apps/web/features/app-shell/hooks/use-fullscreen-shortcut.test.tsx
@@ -18,21 +18,79 @@ function fireKey(key: string, code = "KeyF") {
   );
 }
 
+const originalDescriptors = {
+  requestFullscreen: Object.getOwnPropertyDescriptor(
+    document.documentElement,
+    "requestFullscreen",
+  ),
+  exitFullscreen: Object.getOwnPropertyDescriptor(document, "exitFullscreen"),
+  fullscreenElement: Object.getOwnPropertyDescriptor(
+    document,
+    "fullscreenElement",
+  ),
+};
+
+function setFullscreenApi({
+  requestFullscreen,
+  exitFullscreen,
+  fullscreenElement,
+}: {
+  requestFullscreen?: unknown;
+  exitFullscreen?: unknown;
+  fullscreenElement?: unknown;
+}) {
+  if (requestFullscreen !== undefined) {
+    Object.defineProperty(document.documentElement, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    });
+  }
+  if (exitFullscreen !== undefined) {
+    Object.defineProperty(document, "exitFullscreen", {
+      configurable: true,
+      value: exitFullscreen,
+    });
+  }
+  if (fullscreenElement !== undefined) {
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: fullscreenElement,
+    });
+  }
+}
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  if (originalDescriptors.requestFullscreen) {
+    Object.defineProperty(
+      document.documentElement,
+      "requestFullscreen",
+      originalDescriptors.requestFullscreen,
+    );
+  }
+  if (originalDescriptors.exitFullscreen) {
+    Object.defineProperty(
+      document,
+      "exitFullscreen",
+      originalDescriptors.exitFullscreen,
+    );
+  }
+  if (originalDescriptors.fullscreenElement) {
+    Object.defineProperty(
+      document,
+      "fullscreenElement",
+      originalDescriptors.fullscreenElement,
+    );
+  }
 });
 
 describe("useFullscreenShortcut", () => {
   it("requests fullscreen on F key when not in fullscreen", () => {
     const requestFullscreen = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(document.documentElement, "requestFullscreen", {
-      configurable: true,
-      value: requestFullscreen,
-    });
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      value: null,
+    setFullscreenApi({
+      requestFullscreen,
+      fullscreenElement: null,
     });
 
     render(<Harness />);
@@ -42,14 +100,12 @@ describe("useFullscreenShortcut", () => {
   });
 
   it("exits fullscreen on F key when already in fullscreen", () => {
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
     const exitFullscreen = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(document, "exitFullscreen", {
-      configurable: true,
-      value: exitFullscreen,
-    });
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      value: document.documentElement,
+    setFullscreenApi({
+      requestFullscreen,
+      exitFullscreen,
+      fullscreenElement: document.documentElement,
     });
 
     render(<Harness />);
@@ -60,13 +116,9 @@ describe("useFullscreenShortcut", () => {
 
   it("ignores F key when typing in an input", () => {
     const requestFullscreen = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(document.documentElement, "requestFullscreen", {
-      configurable: true,
-      value: requestFullscreen,
-    });
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      value: null,
+    setFullscreenApi({
+      requestFullscreen,
+      fullscreenElement: null,
     });
 
     render(<Harness />);
@@ -87,13 +139,9 @@ describe("useFullscreenShortcut", () => {
 
   it("ignores F key when Ctrl is held", () => {
     const requestFullscreen = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(document.documentElement, "requestFullscreen", {
-      configurable: true,
-      value: requestFullscreen,
-    });
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      value: null,
+    setFullscreenApi({
+      requestFullscreen,
+      fullscreenElement: null,
     });
 
     render(<Harness />);
@@ -112,13 +160,9 @@ describe("useFullscreenShortcut", () => {
 
   it("triggers regardless of keyboard layout (physical key position)", () => {
     const requestFullscreen = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(document.documentElement, "requestFullscreen", {
-      configurable: true,
-      value: requestFullscreen,
-    });
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      value: null,
+    setFullscreenApi({
+      requestFullscreen,
+      fullscreenElement: null,
     });
 
     render(<Harness />);
@@ -130,13 +174,9 @@ describe("useFullscreenShortcut", () => {
 
   it("ignores a different physical key even if it produces 'f'", () => {
     const requestFullscreen = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(document.documentElement, "requestFullscreen", {
-      configurable: true,
-      value: requestFullscreen,
-    });
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      value: null,
+    setFullscreenApi({
+      requestFullscreen,
+      fullscreenElement: null,
     });
 
     render(<Harness />);
@@ -147,9 +187,8 @@ describe("useFullscreenShortcut", () => {
   });
 
   it("does nothing when fullscreen API is unsupported", () => {
-    Object.defineProperty(document.documentElement, "requestFullscreen", {
-      configurable: true,
-      value: undefined,
+    setFullscreenApi({
+      requestFullscreen: undefined,
     });
 
     render(<Harness />);

--- a/apps/web/features/app-shell/hooks/use-fullscreen-shortcut.test.tsx
+++ b/apps/web/features/app-shell/hooks/use-fullscreen-shortcut.test.tsx
@@ -1,0 +1,158 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useFullscreenShortcut } from "./use-fullscreen-shortcut";
+
+function Harness() {
+  useFullscreenShortcut();
+  return null;
+}
+
+function fireKey(key: string, code = "KeyF") {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key,
+      code,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useFullscreenShortcut", () => {
+  it("requests fullscreen on F key when not in fullscreen", () => {
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(document.documentElement, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
+
+    render(<Harness />);
+    fireKey("f");
+
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("exits fullscreen on F key when already in fullscreen", () => {
+    const exitFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(document, "exitFullscreen", {
+      configurable: true,
+      value: exitFullscreen,
+    });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: document.documentElement,
+    });
+
+    render(<Harness />);
+    fireKey("f");
+
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores F key when typing in an input", () => {
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(document.documentElement, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
+
+    render(<Harness />);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "f",
+        code: "KeyF",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(requestFullscreen).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it("ignores F key when Ctrl is held", () => {
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(document.documentElement, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
+
+    render(<Harness />);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "f",
+        code: "KeyF",
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(requestFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("triggers regardless of keyboard layout (physical key position)", () => {
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(document.documentElement, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
+
+    render(<Harness />);
+    // AZERTY layout: the physical F key produces "a" but has code "KeyF".
+    fireKey("a", "KeyF");
+
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a different physical key even if it produces 'f'", () => {
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(document.documentElement, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
+
+    render(<Harness />);
+    // A different physical key (e.g. KeyA) producing "f" must not trigger.
+    fireKey("f", "KeyA");
+
+    expect(requestFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when fullscreen API is unsupported", () => {
+    Object.defineProperty(document.documentElement, "requestFullscreen", {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(<Harness />);
+    fireKey("f");
+  });
+});

--- a/apps/web/features/app-shell/hooks/use-fullscreen-shortcut.ts
+++ b/apps/web/features/app-shell/hooks/use-fullscreen-shortcut.ts
@@ -23,8 +23,8 @@ export function useFullscreenShortcut() {
     if (!isFullscreenSupported()) return;
 
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.code !== "KeyF") return;
-      if (event.ctrlKey || event.metaKey || event.altKey) return;
+      if (event.code !== "KeyF" || event.repeat) return;
+      if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
       if (isEditableTarget(event.target)) return;
 
       event.preventDefault();

--- a/apps/web/features/app-shell/hooks/use-fullscreen-shortcut.ts
+++ b/apps/web/features/app-shell/hooks/use-fullscreen-shortcut.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return (
+    tag === "input" ||
+    tag === "textarea" ||
+    tag === "select" ||
+    target.isContentEditable
+  );
+}
+
+function isFullscreenSupported(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    typeof document.documentElement.requestFullscreen === "function"
+  );
+}
+
+export function useFullscreenShortcut() {
+  useEffect(() => {
+    if (!isFullscreenSupported()) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.code !== "KeyF") return;
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+      if (isEditableTarget(event.target)) return;
+
+      event.preventDefault();
+
+      if (document.fullscreenElement) {
+        void document.exitFullscreen();
+      } else {
+        void document.documentElement.requestFullscreen();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+}

--- a/apps/web/pages/match/[id].tsx
+++ b/apps/web/pages/match/[id].tsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
+import { useFullscreenShortcut } from "../../features/app-shell/hooks/use-fullscreen-shortcut";
 import EndMatchOverlay from "../../components/ui/EndMatchOverlay";
 import type { Snapshot } from "../../components/ui/types";
 import { requestMatchReport } from "../../features/auth/lib/auth-client";
@@ -134,6 +135,7 @@ function matchSourcePartyInviteCode(
 }
 
 export default function MatchPage() {
+  useFullscreenShortcut();
   const router = useRouter();
   const routeMatchId = router.isReady
     ? normalizeRouteMatchId(router.query.id, router.asPath)


### PR DESCRIPTION
## What

Adds a keyboard shortcut so pressing **F** toggles fullscreen

## How

- New `useFullscreenShortcut` hook under `features/app-shell/hooks`, wired into `AppShell` (lobby/help/player pages) and the `/match/[id]` page (gameplay).
- Uses `document.documentElement.requestFullscreen()` / `document.exitFullscreen()` based on current state.
- Matches on the physical key position (`event.code === "KeyF"`) rather than the produced character, so it works regardless of keyboard layout (e.g. AZERTY/Dvorak).
- Ignores the shortcut while typing in inputs/textareas/selects and when Ctrl/Meta/Alt is held, so it never hijacks browser shortcuts (e.g. Ctrl+F).
- No-ops gracefully when the Fullscreen API is unsupported.

## Testing

- Added `use-fullscreen-shortcut.test.tsx` (7 cases: enter, exit, input-field, modifier, layout independence, wrong physical key, unsupported API) — all pass.
- `npm run lint:architecture`: no findings.
- `npx tsc --noEmit`: clean.

Note: 6 pre-existing failures in `EndMatchOverlay.test.tsx` and `PlayerProfilePage.test.tsx` (number-formatting assertions) are unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut to toggle fullscreen mode while viewing matches.
  * The shortcut avoids disrupting text entry or modified keyboard commands.
  * Fullscreen behavior remains unavailable gracefully when unsupported by the browser.
* **Bug Fixes**
  * Movement and panorama-link controls are now correctly disabled for NMPZ matches with no-movement rules.
* **Tests**
  * Added coverage for fullscreen toggling, keyboard layouts, ignored inputs, modifier keys, and unsupported browser APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->