### PR TITLE
fix: unable to open locations after a match

### DIFF
--- a/apps/web/components/GuessMap.test.tsx
+++ b/apps/web/components/GuessMap.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import GuessMap, { buildGoogleMapsLocationUrl, openLocationInMaps } from './GuessMap';
+
+type RoundPlayerResult = {
+  userId: string;
+  lat: number;
+  lng: number;
+  score: number;
+  distanceKm: number;
+};
+
+type RoundPlayerSeed = {
+  id?: string;
+  result: RoundPlayerResult;
+};
+
+type RoundResult = {
+  roundId?: string;
+  actualLocation: { lat: number; lng: number };
+  players: Record<string, RoundPlayerResult>;
+};
+
+function makeRound(seed: number, players: RoundPlayerSeed[] = []): RoundResult {
+  return {
+    roundId: `round-${seed}`,
+    actualLocation: { lat: 10 + seed, lng: -20 - seed },
+    players: Object.fromEntries(players.map((p, i) => [p.id ?? `p${i}`, p.result]))
+  };
+}
+
+describe('openLocationInMaps', () => {
+  let fakeWindow: { opener: Window | null };
+  beforeEach(() => {
+    fakeWindow = { opener: null };
+    vi.spyOn(window, 'open').mockImplementation(() => fakeWindow as unknown as Window);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens a Google Maps url built from the coordinates', () => {
+    const url = openLocationInMaps(40.7128, -74.006);
+    expect(url).toBe(buildGoogleMapsLocationUrl(40.7128, -74.006));
+    expect(window.open).toHaveBeenCalledTimes(1);
+    expect(window.open).toHaveBeenCalledWith(url, '_blank');
+    expect(fakeWindow.opener).toBeNull();
+  });
+});
+
+describe('GuessMap interactive result markers', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('opens the location when the single-result marker is clicked', async () => {
+    const round = makeRound(1);
+    render(<GuessMap mode="result" result={round} interactiveInResult />);
+
+    await waitFor(() => {
+      const link = document.querySelector('.actualLocationLink');
+      expect(link).not.toBeNull();
+      expect(link?.getAttribute('data-lat')).toBe(String(round.actualLocation.lat));
+      expect(link?.getAttribute('data-lng')).toBe(String(round.actualLocation.lng));
+      fireEvent.click(link as HTMLElement);
+      expect(window.open).toHaveBeenCalledTimes(1);
+    });
+
+    expect(window.open).toHaveBeenCalledWith(
+      buildGoogleMapsLocationUrl(round.actualLocation.lat, round.actualLocation.lng),
+      '_blank'
+    );
+  });
+
+  it('opens each round url exactly once in the multi-round overlay', async () => {
+    const rounds = [makeRound(1), makeRound(2), makeRound(3)];
+    render(<GuessMap mode="result" results={rounds} interactiveInResult />);
+
+    await waitFor(() => {
+      const links = Array.from(document.querySelectorAll('.actualLocationLink'));
+      expect(links.length).toBe(3);
+      links.forEach((link, index) => {
+        expect(link.getAttribute('data-lat')).toBe(String(rounds[index].actualLocation.lat));
+        expect(link.getAttribute('data-lng')).toBe(String(rounds[index].actualLocation.lng));
+        fireEvent.click(link);
+      });
+      expect(window.open).toHaveBeenCalledTimes(3);
+    });
+
+    rounds.forEach((round) => {
+      expect(window.open).toHaveBeenCalledWith(
+        buildGoogleMapsLocationUrl(round.actualLocation.lat, round.actualLocation.lng),
+        '_blank'
+      );
+    });
+  });
+});

--- a/apps/web/components/GuessMap.tsx
+++ b/apps/web/components/GuessMap.tsx
@@ -210,23 +210,11 @@ function WrappedResultLayer({
   resultPlayerBorderColors
 }: WrappedResultLayerProps) {
   const map = useMap();
-  const [viewportVersion, setViewportVersion] = useState(0);
+  const viewportVersion = useResultInteractions(map);
   const actualLocationIcon = useMemo(
     () => createActualLocationIcon(result.actualLocation.lat, result.actualLocation.lng),
     [result.actualLocation.lat, result.actualLocation.lng]
   );
-
-  useMapEvents({
-    move() {
-      setViewportVersion((value) => value + 1);
-    },
-    zoom() {
-      setViewportVersion((value) => value + 1);
-    },
-    resize() {
-      setViewportVersion((value) => value + 1);
-    }
-  });
 
   const layout = useMemo(() => {
     const container = map.getContainer();
@@ -294,19 +282,8 @@ function WrappedResultsLayer({
   resultPlayerBorderColors
 }: WrappedResultsLayerProps) {
   const map = useMap();
-  const [viewportVersion, setViewportVersion] = useState(0);
-
-  useMapEvents({
-    move() {
-      setViewportVersion((value) => value + 1);
-    },
-    zoom() {
-      setViewportVersion((value) => value + 1);
-    },
-    resize() {
-      setViewportVersion((value) => value + 1);
-    }
-  });
+  const viewportVersion = useResultInteractions(map);
+  const actualLocationIcons = useActualLocationIcons(results);
 
   const layout = useMemo(() => {
     const container = map.getContainer();
@@ -337,11 +314,7 @@ function WrappedResultsLayer({
         <Marker
           key={`actual-${round.roundIndex}`}
           position={[round.actualLatLng.lat, round.actualLatLng.lng]}
-          icon={createActualLocationIcon(
-            round.actualLocation.lat,
-            round.actualLocation.lng,
-            round.roundIndex + 1
-          )}
+          icon={actualLocationIcons[round.roundIndex]}
           zIndexOffset={4000}
           title={`Round ${round.roundIndex + 1}: Open actual location in Google Maps`}
         />
@@ -437,6 +410,70 @@ export function buildGoogleMapsLocationUrl(lat: number, lng: number) {
   return `https://www.google.com/maps/@?${params.toString()}`;
 }
 
+export function openLocationInMaps(lat: number, lng: number): string {
+  const url = buildGoogleMapsLocationUrl(lat, lng);
+  if (typeof window !== 'undefined' && typeof window.open === 'function') {
+    const opened = window.open(url, '_blank');
+    if (opened) opened.opener = null;
+  }
+  return url;
+}
+
+function disableMapClickPropagationForActualMarkers(container: HTMLElement) {
+  container
+    .querySelectorAll('.actual-location-marker')
+    .forEach((node) => {
+      const el = node as HTMLElement;
+      if (el.dataset.actualPropagationDisabled) return;
+      L.DomEvent.disableClickPropagation(el);
+      el.dataset.actualPropagationDisabled = '1';
+    });
+}
+
+function useResultInteractions(map: L.Map): number {
+  const [viewportVersion, setViewportVersion] = useState(0);
+
+  useEffect(() => {
+    const container = map.getContainer();
+    
+    disableMapClickPropagationForActualMarkers(container);
+
+    const handleClick = (event: Event) => {
+      const link = (event.target as HTMLElement | null)?.closest<HTMLElement>('.actualLocationLink');
+      if (!link) return;
+      event.preventDefault();
+      const lat = Number(link.dataset.lat);
+      const lng = Number(link.dataset.lng);
+      if (Number.isFinite(lat) && Number.isFinite(lng)) {
+        openLocationInMaps(lat, lng);
+      }
+    };
+    container.addEventListener('click', handleClick, true);
+    return () => container.removeEventListener('click', handleClick, true);
+  }, [map, viewportVersion]);
+
+  useMapEvents({
+    move: () => setViewportVersion((value) => value + 1),
+    zoom: () => setViewportVersion((value) => value + 1),
+    resize: () => setViewportVersion((value) => value + 1)
+  });
+
+  return viewportVersion;
+}
+
+function useActualLocationIcons(results: RoundResult[]): L.DivIcon[] {
+  const signature = results
+    .map((round) => `${round.actualLocation.lat},${round.actualLocation.lng}`)
+    .join('|');
+  return useMemo(
+    () =>
+      results.map((round, index) =>
+        createActualLocationIcon(round.actualLocation.lat, round.actualLocation.lng, index + 1)
+      ),
+    [signature]
+  );
+}
+
 function createAvatarMarkerIcon({
   avatarUrl,
   fallback,
@@ -476,6 +513,8 @@ export function createActualLocationIcon(lat: number, lng: number, roundNumber?:
   const content = label
     ? `<span class="actualLocationNumber">${label}</span>`
     : '<span class="actualLocationFlag"></span>';
+  const latAttr = String(lat);
+  const lngAttr = String(lng);
   const mapsUrl = buildGoogleMapsLocationUrl(lat, lng).replace(/&/g, '&amp;');
   const accessibleLabel = label
     ? `Open round ${label} actual location in Google Maps`
@@ -483,7 +522,7 @@ export function createActualLocationIcon(lat: number, lng: number, roundNumber?:
 
   return L.divIcon({
     className: 'actual-location-marker',
-    html: `<a class="actualLocationLink" href="${mapsUrl}" target="_blank" rel="noopener noreferrer" aria-label="${accessibleLabel}"><span class="actualLocationPin" aria-hidden="true">${content}</span></a>`,
+    html: `<a class="actualLocationLink" href="${mapsUrl}" target="_blank" rel="noopener noreferrer" aria-label="${accessibleLabel}" data-lat="${latAttr}" data-lng="${lngAttr}"><span class="actualLocationPin" aria-hidden="true">${content}</span></a>`,
     iconSize: [30, 30],
     iconAnchor: [15, 15]
   });


### PR DESCRIPTION
Left-clicking an actual-location marker in a match results view did nothing. The draggable MapContainer started a map drag on mousedown over the marker; after any movement Leaflet fired a document-level capture-phase click suppressor that killed the click, so neither native navigation nor our delegated handler fired.

Changes:

Isolate the marker from the map's drag handler via L.DomEvent.disableClickPropagation on the actual-location icon, so the click is never suppressed. A capture-phase delegated listener on the map container opens Google Maps (window.open, _blank, opener = null).
Memoize the multi-round actual-location icons by coordinate signature so Leaflet never recreates the _icon DOM node,  otherwise re-renders of the match-end overlay dropped the click isolation.