### PR TITLE
Fix extension hiding Street View controls outside GeoDuels

### DIFF
--- a/apps/web/features/browser-extension/lib/google-street-view-script.test.ts
+++ b/apps/web/features/browser-extension/lib/google-street-view-script.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import vm from "node:vm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const script = readFileSync(
   resolve(
@@ -18,7 +18,13 @@ type StyleElement = {
   remove: () => void;
 };
 
-function loadGoogleStreetViewScript(referrer: string) {
+class Panorama {
+  setOptions = vi.fn();
+  set = vi.fn();
+  constructor(public element: unknown, public options: unknown) {}
+}
+
+function loadGoogleStreetViewScript(referrer: string, ancestorOrigins?: string[]) {
   const posted: Array<{ data: unknown; targetOrigin: string }> = [];
   const styles = new Map<string, StyleElement>();
   const parent = {
@@ -32,7 +38,7 @@ function loadGoogleStreetViewScript(referrer: string) {
   };
   const iframeWindow: {
     top: typeof parent;
-    location: { search: string; hash: string };
+    location: { search: string; hash: string; ancestorOrigins?: string[] };
     addEventListener: (type: string, handler: (event: MessageEvent) => void) => void;
     document: {
       referrer: string;
@@ -42,11 +48,11 @@ function loadGoogleStreetViewScript(referrer: string) {
       head: { appendChild: (node: StyleElement) => void };
       documentElement: { appendChild: (node: StyleElement) => void };
     };
-    google?: unknown;
+    google?: { maps: { StreetViewPanorama: typeof Panorama } };
     setTimeout: typeof setTimeout;
   } = {
     top: parent,
-    location: { search: "", hash: "" },
+    location: { search: "", hash: "", ancestorOrigins },
     addEventListener(type, handler) {
       if (type === "message") messageListeners.push(handler);
     },
@@ -89,6 +95,7 @@ function loadGoogleStreetViewScript(referrer: string) {
   return {
     posted,
     styles,
+    iframeWindow,
     send(origin: string, data: unknown) {
       const event = {
         source: parent,
@@ -102,7 +109,19 @@ function loadGoogleStreetViewScript(referrer: string) {
 
 describe("google-street-view content script", () => {
   it("accepts GeoDuels configure messages when the iframe referrer is stripped", () => {
-    const { posted, send } = loadGoogleStreetViewScript("");
+    const { posted, styles, iframeWindow, send } = loadGoogleStreetViewScript("");
+    iframeWindow.google = { maps: { StreetViewPanorama: Panorama } };
+    const options = { panControl: true, zoomControl: true, clickToGo: true };
+    const panorama = new iframeWindow.google.maps.StreetViewPanorama(null, options);
+    const original = (panorama as Panorama & { __geoduels: { original: Panorama } }).__geoduels.original;
+
+    expect(styles.size).toBe(0);
+    expect(panorama.options).toBe(options);
+    expect(original.setOptions).not.toHaveBeenCalled();
+    panorama.setOptions(options);
+    panorama.set("panControl", true);
+    expect(original.setOptions).toHaveBeenLastCalledWith(options);
+    expect(original.set).toHaveBeenLastCalledWith("panControl", true);
 
     send("https://geoduels.io", {
       source: "geoduels-app",
@@ -117,7 +136,7 @@ describe("google-street-view content script", () => {
         data: {
           source: "geoduels-extension",
           version: 1,
-          extensionVersion: "0.1.4",
+          extensionVersion: "0.1.5",
           type: "ready",
           capabilities: { heading: true, roadLabels: true },
         },
@@ -127,7 +146,7 @@ describe("google-street-view content script", () => {
         data: {
           source: "geoduels-extension",
           version: 1,
-          extensionVersion: "0.1.4",
+          extensionVersion: "0.1.5",
           type: "configured",
           ruleset: "no_move",
           streetNames: "hidden",
@@ -135,10 +154,17 @@ describe("google-street-view content script", () => {
         targetOrigin: "*",
       },
     ]);
+    expect(styles.has("geoduels-hidden-native-chrome")).toBe(true);
+    expect(original.setOptions).toHaveBeenLastCalledWith(expect.objectContaining({
+      panControl: false,
+      zoomControl: false,
+      clickToGo: false,
+      showRoadLabels: false,
+    }));
   });
 
   it("hides Google's native Street View compass and zoom controls", () => {
-    const { styles } = loadGoogleStreetViewScript("");
+    const { styles } = loadGoogleStreetViewScript("https://geoduels.io/match/test");
     const css = styles.get("geoduels-hidden-native-chrome")?.textContent ?? "";
 
     expect(css).toContain(".gm-compass");
@@ -148,7 +174,7 @@ describe("google-street-view content script", () => {
   });
 
   it("ignores configure messages from untrusted origins even with an empty referrer", () => {
-    const { posted, send } = loadGoogleStreetViewScript("");
+    const { posted, styles, send } = loadGoogleStreetViewScript("");
 
     send("https://evil.example", {
       source: "geoduels-app",
@@ -159,5 +185,22 @@ describe("google-street-view content script", () => {
     });
 
     expect(posted).toEqual([]);
+    expect(styles.size).toBe(0);
+  });
+
+  it("leaves untrusted embeds untouched, including when ancestorOrigins overrides the referrer", () => {
+    for (const [referrer, ancestors] of [
+      ["https://geoduels.io.evil.example", undefined],
+      ["https://geoduels.io", ["https://unrelated.example"]],
+    ] as const) {
+      const { styles, iframeWindow } = loadGoogleStreetViewScript(referrer, ancestors ? [...ancestors] : undefined);
+      expect(styles.size).toBe(0);
+      expect(Object.getOwnPropertyDescriptor(iframeWindow, "google")).toBeUndefined();
+    }
+  });
+
+  it("enables GeoDuels embeds with an ancestor origin and no referrer", () => {
+    const { styles } = loadGoogleStreetViewScript("", ["https://play.geoduels.io"]);
+    expect(styles.has("geoduels-hidden-native-chrome")).toBe(true);
   });
 });

--- a/extensions/geoduels-enhancer/README.md
+++ b/extensions/geoduels-enhancer/README.md
@@ -14,6 +14,18 @@ The app owns all visible UI and launch preferences. The extension:
 - enforces No Move matches inside the Google frame;
 - has no background worker, account access, analytics, or remote code.
 
+The Google-frame script checks the embedding origin before changing controls or
+hooking Street View. It uses `ancestorOrigins` when available and otherwise the
+document referrer. Non-GeoDuels embeds are left untouched. If both origin signals
+are unavailable, enhancements stay inactive until a trusted GeoDuels configure
+message arrives.
+
+Run the minimal, local script checks with:
+
+```sh
+npm --prefix apps/web test -- features/browser-extension/lib/google-street-view-script.test.ts
+```
+
 ## Local installation
 
 The checked-in `manifest.json` includes localhost matches for development.

--- a/extensions/geoduels-enhancer/manifest.json
+++ b/extensions/geoduels-enhancer/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GeoDuels Enhancer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Official GeoDuels extension that enhances Street View with hidden street names, new modes, a compass, and more.",
   "content_scripts": [
     {

--- a/extensions/geoduels-enhancer/src/geoduels-page.js
+++ b/extensions/geoduels-enhancer/src/geoduels-page.js
@@ -1,6 +1,6 @@
 (() => {
   "use strict";
-  const EXTENSION_VERSION = "0.1.4";
+  const EXTENSION_VERSION = "0.1.5";
   const ready = () => {
     window.postMessage({ source: "geoduels-extension", version: 1, extensionVersion: EXTENSION_VERSION, type: "extension_ready" }, location.origin);
   };

--- a/extensions/geoduels-enhancer/src/google-street-view.js
+++ b/extensions/geoduels-enhancer/src/google-street-view.js
@@ -1,7 +1,15 @@
 (() => {
   "use strict";
   if (window.top === window) return;
-  const VERSION = 1, EXTENSION_VERSION = "0.1.4", EXTENSION = "geoduels-extension", APP = "geoduels-app";
+  // Google embed URL matches also cover other sites. Check the embedding
+  // origin before injecting styles, intercepting keys, or hooking Google.
+  // Firefox lacks ancestorOrigins, so use its document referrer instead.
+  const embeddingOrigin = location.ancestorOrigins?.[0] ?? document.referrer;
+  if (embeddingOrigin && !allowed(embeddingOrigin)) return;
+  // With a stripped referrer, capture panoramas without changing their
+  // behavior until the existing GeoDuels configure handshake authenticates us.
+  let enhancementsEnabled = allowed(embeddingOrigin);
+  const VERSION = 1, EXTENSION_VERSION = "0.1.5", EXTENSION = "geoduels-extension", APP = "geoduels-app";
   const STYLE_ID = "geoduels-hidden-streetnames";
   const CHROME_STYLE_ID = "geoduels-hidden-native-chrome";
   const instances = new Set();
@@ -48,12 +56,14 @@
     style.textContent = css;
   }
   function syncChromeStyle() {
+    if (!enhancementsEnabled) return;
     ensureStyle(
       CHROME_STYLE_ID,
       ".gm-compass,.gm-bundled-control,button[aria-label='Zoom in'],button[aria-label='Zoom out'],button[title='Zoom in'],button[title='Zoom out']{display:none!important}",
     );
   }
   function syncAddressStyle() {
+    if (!enhancementsEnabled) return;
     let style = document.getElementById(STYLE_ID);
     if (config.streetNames !== "hidden") {
       style?.remove();
@@ -62,6 +72,7 @@
     ensureStyle(STYLE_ID, ".gm-iv-address,.gm-iv-address-description,.gm-iv-address-link,.gm-iv-profile-url{display:none!important}");
   }
   function options(extra) {
+    if (!enhancementsEnabled) return extra;
     const hidden = config.streetNames === "hidden";
     const noMove = config.ruleset === "no_move" || config.ruleset === "nmpz";
     return {
@@ -90,7 +101,7 @@
     return ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "w", "a", "s", "d"].includes(key);
   }
   function blockMovementKey(event) {
-    if (config.ruleset !== "no_move" || !isMovementKey(event)) return;
+    if (!enhancementsEnabled || config.ruleset !== "no_move" || !isMovementKey(event)) return;
     event.preventDefault();
     event.stopImmediatePropagation();
   }
@@ -104,6 +115,7 @@
     if (Number.isFinite(heading)) post({ type: "pov", heading });
   }
   function apply(panorama) {
+    if (!enhancementsEnabled) return;
     const state = panorama.__geoduels;
     state.original.setOptions?.call(panorama, options());
     syncChromeStyle();
@@ -115,6 +127,7 @@
     if (state.spawnPosition && current && !samePosition(current, state.spawnPosition)) state.original.setPosition?.call(panorama, state.spawnPosition);
   }
   function protectedValue(key, value) {
+    if (!enhancementsEnabled) return value;
     if (key === "panControl" || key === "zoomControl") return false;
     if (config.streetNames === "hidden" && (key === "showRoadLabels" || key === "addressControl")) return false;
     if ((config.ruleset === "no_move" || config.ruleset === "nmpz") && (key === "clickToGo" || key === "linksControl")) return false;
@@ -137,11 +150,11 @@
     };
     panorama.setPano = function (value) {
       const spawn = panorama.__geoduels.spawnPano;
-      return original.setPano?.call(this, config.ruleset === "no_move" && spawn ? spawn : value);
+      return original.setPano?.call(this, enhancementsEnabled && config.ruleset === "no_move" && spawn ? spawn : value);
     };
     panorama.setPosition = function (value) {
       const spawn = panorama.__geoduels.spawnPosition;
-      const locked = config.ruleset === "no_move" && spawn && !samePosition(value, spawn);
+      const locked = enhancementsEnabled && config.ruleset === "no_move" && spawn && !samePosition(value, spawn);
       return original.setPosition?.call(this, locked ? spawn : value);
     };
     instances.add(panorama);
@@ -197,7 +210,9 @@
       event.data?.type !== "configure"
     ) return;
     parentTrusted = true;
+    enhancementsEnabled = true;
     config = { ruleset: normalizeRuleset(event.data.ruleset), streetNames: normalizeStreetNames(event.data.streetNames) };
+    syncChromeStyle();
     syncAddressStyle();
     instances.forEach(apply);
     instances.forEach(reportHeading);


### PR DESCRIPTION
Google Maps embeds on unrelated sites were losing their native compass and zoom controls because the extension applied styles and panorama overrides before verifying the embedding site.

Check the embedding origin before initializing enhancements. Known non-GeoDuels embeds now exit immediately; when origin information is stripped, panorama behavior and controls remain unchanged until a trusted GeoDuels configure message arrives. Preserve early GeoDuels setup and release version metadata as 0.1.5.

Validation:
- Seven local extension tests pass, with two minimal added cases and updates to the existing handshake tests. No external-site tests added or run.
- TypeScript check and both frontend architecture checks pass.
- Chrome and Firefox 0.1.5 archives build successfully.

Browser-store publication is separate from this PR.
